### PR TITLE
Fix references to the old repo

### DIFF
--- a/setup-claude-code.sh
+++ b/setup-claude-code.sh
@@ -16,7 +16,7 @@ if [ ! -d "$HOME/.agent-os/instructions" ] || [ ! -d "$HOME/.agent-os/standards"
     echo "Please install the Agent OS base installation first:"
     echo ""
     echo "Option 1 - Automatic installation:"
-    echo "  curl -sSL https://raw.githubusercontent.com/instrumental-products/agent-os/main/setup.sh | bash"
+    echo "  curl -sSL https://raw.githubusercontent.com/buildermethods/agent-os/main/setup.sh | bash"
     echo ""
     echo "Option 2 - Manual installation:"
     echo "  Follow instructions at https://buildermethods.com/agent-os"
@@ -25,7 +25,7 @@ if [ ! -d "$HOME/.agent-os/instructions" ] || [ ! -d "$HOME/.agent-os/standards"
 fi
 
 # Base URL for raw GitHub content
-BASE_URL="https://raw.githubusercontent.com/instrumental-products/agent-os/main"
+BASE_URL="https://raw.githubusercontent.com/buildermethods/agent-os/main"
 
 # Create directories
 echo "📁 Creating directories..."

--- a/setup-cursor.sh
+++ b/setup-cursor.sh
@@ -16,7 +16,7 @@ if [ ! -d "$HOME/.agent-os/instructions" ] || [ ! -d "$HOME/.agent-os/standards"
     echo "Please install the Agent OS base installation first:"
     echo ""
     echo "Option 1 - Automatic installation:"
-    echo "  curl -sSL https://raw.githubusercontent.com/instrumental-products/agent-os/main/setup.sh | bash"
+    echo "  curl -sSL https://raw.githubusercontent.com/buildermethods/agent-os/main/setup.sh | bash"
     echo ""
     echo "Option 2 - Manual installation:"
     echo "  Follow instructions at https://buildermethods.com/agent-os"
@@ -29,7 +29,7 @@ echo "📁 Creating .cursor/rules directory..."
 mkdir -p .cursor/rules
 
 # Base URL for raw GitHub content
-BASE_URL="https://raw.githubusercontent.com/instrumental-products/agent-os/main"
+BASE_URL="https://raw.githubusercontent.com/buildermethods/agent-os/main"
 
 echo ""
 echo "📥 Downloading and setting up Cursor command files..."

--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,7 @@ echo "========================"
 echo ""
 
 # Base URL for raw GitHub content
-BASE_URL="https://raw.githubusercontent.com/instrumental-products/agent-os/main"
+BASE_URL="https://raw.githubusercontent.com/buildermethods/agent-os/main"
 
 # Create directories
 echo "📁 Creating directories..."
@@ -169,10 +169,10 @@ echo ""
 echo "2. Install commands for your AI coding assistant(s):"
 echo ""
 echo "   - Using Claude Code? Install the Claude Code commands with:"
-echo "     curl -sSL https://raw.githubusercontent.com/instrumental-products/agent-os/main/setup-claude-code.sh | bash"
+echo "     curl -sSL https://raw.githubusercontent.com/buildermethods/agent-os/main/setup-claude-code.sh | bash"
 echo ""
 echo "   - Using Cursor? Install the Cursor commands with:"
-echo "     curl -sSL https://raw.githubusercontent.com/instrumental-products/agent-os/main/setup-cursor.sh | bash"
+echo "     curl -sSL https://raw.githubusercontent.com/buildermethods/agent-os/main/setup-cursor.sh | bash"
 echo ""
 echo "   - Using something else? See instructions at https://buildermethods.com/agent-os"
 echo ""


### PR DESCRIPTION
Looks like the code was moved to a new repo but the references within the code still referenced the old repo name. To avoid having a split brain scenario, let's update the references