### PR TITLE
fix: Change CamelCase to PascalCase for clarity

### DIFF
--- a/standards/code-style.md
+++ b/standards/code-style.md
@@ -16,7 +16,7 @@ This file is part of the Agent OS standards system. These global code style rule
 
 ### Naming Conventions
 - **Methods and Variables**: Use snake_case (e.g., `user_profile`, `calculate_total`)
-- **Classes and Modules**: Use CamelCase (e.g., `UserProfile`, `PaymentProcessor`)
+- **Classes and Modules**: Use PascalCase (e.g., `UserProfile`, `PaymentProcessor`)
 - **Constants**: Use UPPER_SNAKE_CASE (e.g., `MAX_RETRY_COUNT`)
 
 ### String Formatting


### PR DESCRIPTION
# Description

This PR changes "CamelCase" to "PascalCase" in the standards/code_style.md example. 

## Why make this change?
As someone focused mostly on functional programming I would normally see "camelCase" and "PascalCase" rather than "CamelCase". It's very minor and possibly pedantic, but I think its better to be explicit about it.