### PR TITLE
feat(setup): support local install via --local and --repo-path flags

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,8 @@ set -e  # Exit on error
 # Initialize flags
 OVERWRITE_INSTRUCTIONS=false
 OVERWRITE_STANDARDS=false
+USE_LOCAL=false
+REPO_PATH=""
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -20,12 +22,22 @@ while [[ $# -gt 0 ]]; do
             OVERWRITE_STANDARDS=true
             shift
             ;;
+        --local)
+            USE_LOCAL=true
+            shift
+            ;;
+        --repo-path)
+            REPO_PATH="$2"
+            shift 2
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Options:"
             echo "  --overwrite-instructions    Overwrite existing instruction files"
             echo "  --overwrite-standards       Overwrite existing standards files"
+            echo "  --local                     Install from local repo instead of remote"
+            echo "  --repo-path <path>          Path to local repo (defaults to script directory)"
             echo "  -h, --help                  Show this help message"
             echo ""
             exit 0
@@ -42,8 +54,29 @@ echo "🚀 Agent OS Setup Script"
 echo "========================"
 echo ""
 
-# Base URL for raw GitHub content
+# Determine source
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE_URL="https://raw.githubusercontent.com/buildermethods/agent-os/main"
+
+if [ "$USE_LOCAL" = true ]; then
+  if [ -z "$REPO_PATH" ]; then
+    REPO_PATH="$SCRIPT_DIR"
+  fi
+  echo "📦 Using local source: $REPO_PATH"
+else
+  echo "🌐 Using remote source: $BASE_URL"
+fi
+
+# Helper to fetch a file from local or remote
+fetch_to() {
+  local dest="$1"
+  local rel="$2"
+  if [ "$USE_LOCAL" = true ]; then
+    cp "$REPO_PATH/$rel" "$dest"
+  else
+    curl -s -o "$dest" "${BASE_URL}/$rel"
+  fi
+}
 
 # Create directories
 echo "📁 Creating directories..."
@@ -61,7 +94,7 @@ echo "📥 Downloading standards files to ~/.agent-os/standards/"
 if [ -f "$HOME/.agent-os/standards/tech-stack.md" ] && [ "$OVERWRITE_STANDARDS" = false ]; then
     echo "  ⚠️  ~/.agent-os/standards/tech-stack.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/standards/tech-stack.md" "${BASE_URL}/standards/tech-stack.md"
+    fetch_to "$HOME/.agent-os/standards/tech-stack.md" "standards/tech-stack.md"
     if [ -f "$HOME/.agent-os/standards/tech-stack.md" ] && [ "$OVERWRITE_STANDARDS" = true ]; then
         echo "  ✓ ~/.agent-os/standards/tech-stack.md (overwritten)"
     else
@@ -73,7 +106,7 @@ fi
 if [ -f "$HOME/.agent-os/standards/code-style.md" ] && [ "$OVERWRITE_STANDARDS" = false ]; then
     echo "  ⚠️  ~/.agent-os/standards/code-style.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/standards/code-style.md" "${BASE_URL}/standards/code-style.md"
+    fetch_to "$HOME/.agent-os/standards/code-style.md" "standards/code-style.md"
     if [ -f "$HOME/.agent-os/standards/code-style.md" ] && [ "$OVERWRITE_STANDARDS" = true ]; then
         echo "  ✓ ~/.agent-os/standards/code-style.md (overwritten)"
     else
@@ -85,7 +118,7 @@ fi
 if [ -f "$HOME/.agent-os/standards/best-practices.md" ] && [ "$OVERWRITE_STANDARDS" = false ]; then
     echo "  ⚠️  ~/.agent-os/standards/best-practices.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/standards/best-practices.md" "${BASE_URL}/standards/best-practices.md"
+    fetch_to "$HOME/.agent-os/standards/best-practices.md" "standards/best-practices.md"
     if [ -f "$HOME/.agent-os/standards/best-practices.md" ] && [ "$OVERWRITE_STANDARDS" = true ]; then
         echo "  ✓ ~/.agent-os/standards/best-practices.md (overwritten)"
     else
@@ -101,7 +134,7 @@ echo "📥 Downloading code style files to ~/.agent-os/standards/code-style/"
 if [ -f "$HOME/.agent-os/standards/code-style/css-style.md" ] && [ "$OVERWRITE_STANDARDS" = false ]; then
     echo "  ⚠️  ~/.agent-os/standards/code-style/css-style.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/standards/code-style/css-style.md" "${BASE_URL}/standards/code-style/css-style.md"
+    fetch_to "$HOME/.agent-os/standards/code-style/css-style.md" "standards/code-style/css-style.md"
     if [ -f "$HOME/.agent-os/standards/code-style/css-style.md" ] && [ "$OVERWRITE_STANDARDS" = true ]; then
         echo "  ✓ ~/.agent-os/standards/code-style/css-style.md (overwritten)"
     else
@@ -113,7 +146,7 @@ fi
 if [ -f "$HOME/.agent-os/standards/code-style/html-style.md" ] && [ "$OVERWRITE_STANDARDS" = false ]; then
     echo "  ⚠️  ~/.agent-os/standards/code-style/html-style.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/standards/code-style/html-style.md" "${BASE_URL}/standards/code-style/html-style.md"
+    fetch_to "$HOME/.agent-os/standards/code-style/html-style.md" "standards/code-style/html-style.md"
     if [ -f "$HOME/.agent-os/standards/code-style/html-style.md" ] && [ "$OVERWRITE_STANDARDS" = true ]; then
         echo "  ✓ ~/.agent-os/standards/code-style/html-style.md (overwritten)"
     else
@@ -125,7 +158,7 @@ fi
 if [ -f "$HOME/.agent-os/standards/code-style/javascript-style.md" ] && [ "$OVERWRITE_STANDARDS" = false ]; then
     echo "  ⚠️  ~/.agent-os/standards/code-style/javascript-style.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/standards/code-style/javascript-style.md" "${BASE_URL}/standards/code-style/javascript-style.md"
+    fetch_to "$HOME/.agent-os/standards/code-style/javascript-style.md" "standards/code-style/javascript-style.md"
     if [ -f "$HOME/.agent-os/standards/code-style/javascript-style.md" ] && [ "$OVERWRITE_STANDARDS" = true ]; then
         echo "  ✓ ~/.agent-os/standards/code-style/javascript-style.md (overwritten)"
     else
@@ -144,7 +177,7 @@ echo "  📂 Core instructions:"
 if [ -f "$HOME/.agent-os/instructions/core/plan-product.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = false ]; then
     echo "    ⚠️  ~/.agent-os/instructions/core/plan-product.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/instructions/core/plan-product.md" "${BASE_URL}/instructions/core/plan-product.md"
+    fetch_to "$HOME/.agent-os/instructions/core/plan-product.md" "instructions/core/plan-product.md"
     if [ -f "$HOME/.agent-os/instructions/core/plan-product.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = true ]; then
         echo "    ✓ ~/.agent-os/instructions/core/plan-product.md (overwritten)"
     else
@@ -156,7 +189,7 @@ fi
 if [ -f "$HOME/.agent-os/instructions/core/create-spec.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = false ]; then
   echo "    ⚠️  ~/.agent-os/instructions/core/create-spec.md already exists - skipping"
 else
-  curl -s -o "$HOME/.agent-os/instructions/core/create-spec.md" "${BASE_URL}/instructions/core/create-spec.md"
+  fetch_to "$HOME/.agent-os/instructions/core/create-spec.md" "instructions/core/create-spec.md"
   if [ -f "$HOME/.agent-os/instructions/core/create-spec.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = true ]; then
     echo "    ✓ ~/.agent-os/instructions/core/create-spec.md (overwritten)"
   else
@@ -168,7 +201,7 @@ fi
 if [ -f "$HOME/.agent-os/instructions/core/execute-tasks.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = false ]; then
     echo "    ⚠️  ~/.agent-os/instructions/core/execute-tasks.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/instructions/core/execute-tasks.md" "${BASE_URL}/instructions/core/execute-tasks.md"
+    fetch_to "$HOME/.agent-os/instructions/core/execute-tasks.md" "instructions/core/execute-tasks.md"
     if [ -f "$HOME/.agent-os/instructions/core/execute-tasks.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = true ]; then
         echo "    ✓ ~/.agent-os/instructions/core/execute-tasks.md (overwritten)"
     else
@@ -180,7 +213,7 @@ fi
 if [ -f "$HOME/.agent-os/instructions/core/execute-task.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = false ]; then
     echo "    ⚠️  ~/.agent-os/instructions/core/execute-task.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/instructions/core/execute-task.md" "${BASE_URL}/instructions/core/execute-task.md"
+    fetch_to "$HOME/.agent-os/instructions/core/execute-task.md" "instructions/core/execute-task.md"
     if [ -f "$HOME/.agent-os/instructions/core/execute-task.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = true ]; then
         echo "    ✓ ~/.agent-os/instructions/core/execute-task.md (overwritten)"
     else
@@ -192,13 +225,14 @@ fi
 if [ -f "$HOME/.agent-os/instructions/core/analyze-product.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = false ]; then
     echo "    ⚠️  ~/.agent-os/instructions/core/analyze-product.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/instructions/core/analyze-product.md" "${BASE_URL}/instructions/core/analyze-product.md"
+    fetch_to "$HOME/.agent-os/instructions/core/analyze-product.md" "instructions/core/analyze-product.md"
     if [ -f "$HOME/.agent-os/instructions/core/analyze-product.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = true ]; then
         echo "    ✓ ~/.agent-os/instructions/core/analyze-product.md (overwritten)"
     else
         echo "    ✓ ~/.agent-os/instructions/core/analyze-product.md"
     fi
 fi
+
 
 # Meta instruction files
 echo ""
@@ -208,7 +242,7 @@ echo "  📂 Meta instructions:"
 if [ -f "$HOME/.agent-os/instructions/meta/pre-flight.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = false ]; then
     echo "    ⚠️  ~/.agent-os/instructions/meta/pre-flight.md already exists - skipping"
 else
-    curl -s -o "$HOME/.agent-os/instructions/meta/pre-flight.md" "${BASE_URL}/instructions/meta/pre-flight.md"
+    fetch_to "$HOME/.agent-os/instructions/meta/pre-flight.md" "instructions/meta/pre-flight.md"
     if [ -f "$HOME/.agent-os/instructions/meta/pre-flight.md" ] && [ "$OVERWRITE_INSTRUCTIONS" = true ]; then
         echo "    ✓ ~/.agent-os/instructions/meta/pre-flight.md (overwritten)"
     else


### PR DESCRIPTION
Changes
- Add --local and --repo-path flags to setup.sh, setup-claude-code.sh, setup-cursor.sh
- Default repo path to the directory of the script when --local is used and --repo-path is omitted
- Introduce fetch_to helper to switch between remote curl and local cp
- Preserve existing behavior as default (remote install)

Usage
- Base install (local):
  - ./setup.sh --local [--repo-path /path/to/repo]
- Claude commands (local):
  - ./setup-claude-code.sh --local [--repo-path /path/to/repo]
- Cursor rules (local):
  - ./setup-cursor.sh --local [--repo-path /path/to/repo]

Note: I found it helpful to have these flags while modifying the agent-os repository locally. Currently, the setup scripts pull only from the remote repo.