### PR TITLE
Updates to help claude code understand how to find .agent-os in the user's profile, especially on Windows.

### DIFF
--- a/commands/analyze-product.md
+++ b/commands/analyze-product.md
@@ -2,4 +2,8 @@
 
 Analyze your product's codebase and install Agent OS
 
-Refer to the instructions located in @~/.agent-os/instructions/core/analyze-product.md
+Any file references beginning with `~` refer to path under the current user's profile. You'll need to replace the `~` with the user's path. Before using any path with `~` in this document, first determine the correct user profile path by running:
+  - **Windows**: `Bash(echo $USERPROFILE)`
+  - **macOS/Linux**: `echo $HOME`
+
+Refer to the instructions located in @~/.agent-os/instructions/core/analyze-product.md. If you can not find this file DO NOT CONTINUE, ask the user for help.

--- a/commands/create-spec.md
+++ b/commands/create-spec.md
@@ -2,4 +2,8 @@
 
 Create a detailed spec for a new feature with technical specifications and task breakdown
 
-Refer to the instructions located in @~/.agent-os/instructions/core/create-spec.md
+Any file references beginning with `~` refer to path under the current user's profile. You'll need to replace the `~` with the user's path. Before using any path with `~` in this document, first determine the correct user profile path by running:
+  - **Windows**: `Bash(echo $USERPROFILE)`
+  - **macOS/Linux**: `echo $HOME`
+
+Refer to the instructions located in @~/.agent-os/instructions/core/create-spec.md. If you can not find this file DO NOT CONTINUE, ask the user for help.

--- a/commands/execute-tasks.md
+++ b/commands/execute-tasks.md
@@ -2,4 +2,8 @@
 
 Execute the next task.
 
-Refer to the instructions located in @~/.agent-os/instructions/core/execute-tasks.md
+Any file references beginning with `~` refer to path under the current user's profile. You'll need to replace the `~` with the user's path. Before using any path with `~` in this document, first determine the correct user profile path by running:
+  - **Windows**: `Bash(echo $USERPROFILE)`
+  - **macOS/Linux**: `echo $HOME`
+
+Refer to the instructions located in @~/.agent-os/instructions/core/execute-tasks.md. If you can not find this file DO NOT CONTINUE, ask the user for help.

--- a/commands/plan-product.md
+++ b/commands/plan-product.md
@@ -2,4 +2,8 @@
 
 Plan a new product and install Agent OS in its codebase.
 
-Refer to the instructions located in @~/.agent-os/instructions/core/plan-product.md
+Any file references beginning with `~` refer to path under the current user's profile. You'll need to replace the `~` with the user's path. Before using any path with `~` in this document, first determine the correct user profile path by running:
+  - **Windows**: `Bash(echo $USERPROFILE)`
+  - **macOS/Linux**: `echo $HOME`
+
+Refer to the instructions located in @~/.agent-os/instructions/core/plan-product.md. If you can not find this file DO NOT CONTINUE, ask the user for help.


### PR DESCRIPTION
Initially claude-code wasn't following the agent-os instructions on Windows. I made these updates and it can now find the proper files.  