### PR TITLE
Analyze Product Command: Add composer.json (PHP) to list of dependencies

### DIFF
--- a/instructions/core/analyze-product.md
+++ b/instructions/core/analyze-product.md
@@ -33,7 +33,7 @@ Perform a deep codebase analysis of the current codebase to understand current s
   </project_structure>
   <technology_stack>
     - Frameworks in use
-    - Dependencies (package.json, Gemfile, requirements.txt, etc.)
+    - Dependencies (package.json, Gemfile, composer.json, requirements.txt, etc.)
     - Database systems
     - Infrastructure configuration
   </technology_stack>


### PR DESCRIPTION
This PR make sure the analyze product command looks at any relevant composer.json files for dependencies.

I think in most cases Claude would be smart enough to look at composer.json based on the context and the "etc." but I feel like there's enough of us PHP/Laravel devs out there that this should be explicit. 

