### PR TITLE
Extend project types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node_modules/
 # Temporary files
 *.tmp
 *.temp
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -30,3 +30,31 @@ Get Brian's free resources on building with AI:
 - [Builder Briefing newsletter](https://buildermethods.com)
 - [YouTube](https://youtube.com/@briancasel)
 
+---
+
+### Fork Enhancements
+
+This fork extends Agent OS with enhanced project type capabilities:
+
+#### Dynamic Project Types
+- **Custom Commands**: Each project type can define its own set of commands beyond the defaults
+- **Custom Claude Code Agents**: Project types can include specialized agents tailored to specific workflows
+- **Flexible Configuration**: New fields in `config.yml` for commands and claude_code_agents paths per project type
+- **Automatic Discovery**: Installers dynamically detect and copy all `.md` files from project type directories
+
+#### Example Configuration
+```yaml
+project_types:
+  webapp:
+    instructions: ~/.agent-os/project_types/webapp/instructions
+    standards: ~/.agent-os/project_types/webapp/standards
+    commands: ~/.agent-os/project_types/webapp/commands
+    claude_code_agents: ~/.agent-os/project_types/webapp/claude-code/agents
+```
+
+#### Benefits
+- Create domain-specific workflows (e.g., webapp, mobile, API, data-science project types)
+- Add custom agents for specialized tasks without modifying core Agent OS
+- Override default commands while maintaining fallback to standard ones
+- Seamless integration with existing Agent OS installation process
+

--- a/config.yml
+++ b/config.yml
@@ -18,12 +18,6 @@ project_types:
     commands: ~/.agent-os/commands
     claude_code_agents: ~/.agent-os/claude-code/agents
 
-  webapp:
-    instructions: ~/.agent-os/project_types/webapp/instructions
-    standards: ~/.agent-os/project_types/webapp/standards
-    commands: ~/.agent-os/project_types/webapp/commands
-    claude_code_agents: ~/.agent-os/project_types/webapp/claude-code/agents
-
   # type_a:
   #   instructions: ~/.agent-os/project_types/type_a/instructions
   #   standards: ~/.agent-os/project_types/type_a/standards

--- a/config.yml
+++ b/config.yml
@@ -15,13 +15,25 @@ project_types:
   default:
     instructions: ~/.agent-os/instructions
     standards: ~/.agent-os/standards
+    commands: ~/.agent-os/commands
+    claude_code_agents: ~/.agent-os/claude-code/agents
+
+  webapp:
+    instructions: ~/.agent-os/project_types/webapp/instructions
+    standards: ~/.agent-os/project_types/webapp/standards
+    commands: ~/.agent-os/project_types/webapp/commands
+    claude_code_agents: ~/.agent-os/project_types/webapp/claude-code/agents
 
   # type_a:
   #   instructions: ~/.agent-os/project_types/type_a/instructions
   #   standards: ~/.agent-os/project_types/type_a/standards
+  #   commands: ~/.agent-os/project_types/type_a/commands
+  #   claude_code_agents: ~/.agent-os/project_types/type_a/claude-code/agents
 
   # type_b:
   #   instructions: ~/.agent-os/project_types/type_b/instructions
   #   standards: ~/.agent-os/project_types/type_b/standards
+  #   commands: ~/.agent-os/project_types/type_b/commands
+  #   claude_code_agents: ~/.agent-os/project_types/type_b/claude-code/agents
 
 default_project_type: default

--- a/setup/base.sh
+++ b/setup/base.sh
@@ -84,8 +84,8 @@ source "$INSTALL_DIR/setup/functions.sh"
 echo ""
 echo "📦 Installing the latest version of Agent OS from the Agent OS GitHub repository..."
 
-# Install /instructions, /standards, and /commands folders and files from GitHub
-install_from_github "$INSTALL_DIR" "$OVERWRITE_INSTRUCTIONS" "$OVERWRITE_STANDARDS"
+# Install /instructions, /standards, /commands, and /claude-code folders and files from GitHub
+install_from_github "$INSTALL_DIR" "$OVERWRITE_INSTRUCTIONS" "$OVERWRITE_STANDARDS" true
 
 # Download config.yml
 echo ""
@@ -104,24 +104,14 @@ download_file "${BASE_URL}/setup/project.sh" \
     "setup/project.sh"
 chmod +x "$INSTALL_DIR/setup/project.sh"
 
-# Handle Claude Code installation
+# Handle Claude Code enablement in config
 if [ "$CLAUDE_CODE" = true ]; then
     echo ""
-    echo "📥 Downloading Claude Code agent templates..."
-    mkdir -p "$INSTALL_DIR/claude-code/agents"
-
-    # Download agents to base installation for project use
-    echo "  📂 Agent templates:"
-    for agent in context-fetcher date-checker file-creator git-workflow project-manager test-runner; do
-        download_file "${BASE_URL}/claude-code/agents/${agent}.md" \
-            "$INSTALL_DIR/claude-code/agents/${agent}.md" \
-            "false" \
-            "claude-code/agents/${agent}.md"
-    done
-
+    echo "📥 Enabling Claude Code support..."
     # Update config to enable claude_code
     if [ -f "$INSTALL_DIR/config.yml" ]; then
         sed -i.bak '/claude_code:/,/enabled:/ s/enabled: false/enabled: true/' "$INSTALL_DIR/config.yml" && rm "$INSTALL_DIR/config.yml.bak"
+        echo "  ✓ Claude Code enabled in configuration"
     fi
 fi
 
@@ -157,12 +147,9 @@ echo "📍 Base installation files installed to:"
 echo "   $INSTALL_DIR/instructions/      - Agent OS instructions"
 echo "   $INSTALL_DIR/standards/         - Development standards"
 echo "   $INSTALL_DIR/commands/          - Command templates"
+echo "   $INSTALL_DIR/claude-code/agents/ - Claude Code agent templates"
 echo "   $INSTALL_DIR/config.yml         - Configuration"
 echo "   $INSTALL_DIR/setup/project.sh   - Project installation script"
-
-if [ "$CLAUDE_CODE" = true ]; then
-    echo "   $INSTALL_DIR/claude-code/agents/ - Claude Code agent templates"
-fi
 
 echo ""
 echo "--------------------------------"

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -183,5 +183,17 @@ install_from_github() {
                 "$overwrite_std" \
                 "commands/${cmd}.md"
         done
+
+        # Download Claude Code agents
+        echo ""
+        echo "📥 Downloading Claude Code agent files to $target_dir/claude-code/agents/"
+        mkdir -p "$target_dir/claude-code/agents"
+
+        for agent in context-fetcher date-checker file-creator git-workflow project-manager test-runner; do
+            download_file "${BASE_URL}/claude-code/agents/${agent}.md" \
+                "$target_dir/claude-code/agents/${agent}.md" \
+                "$overwrite_std" \
+                "claude-code/agents/${agent}.md"
+        done
     fi
 }


### PR DESCRIPTION
This PR extends Agent OS with enhanced project type capabilities:

#### Dynamic Project Types
- **Custom Commands**: Each project type can define its own set of commands beyond the defaults
- **Custom Claude Code Agents**: Project types can include specialized agents tailored to specific workflows
- **Flexible Configuration**: New fields in `config.yml` for commands and claude_code_agents paths per project type
- **Automatic Discovery**: Installers dynamically detect and copy all `.md` files from project type directories

#### Example Configuration
```yaml
project_types:
  webapp:
    instructions: ~/.agent-os/project_types/webapp/instructions
    standards: ~/.agent-os/project_types/webapp/standards
    commands: ~/.agent-os/project_types/webapp/commands
    claude_code_agents: ~/.agent-os/project_types/webapp/claude-code/agents
```

#### Benefits
- Create domain-specific workflows (e.g., webapp, mobile, API, data-science project types)
- Add custom agents for specialized tasks without modifying core Agent OS
- Override default commands while maintaining fallback to standard ones
- Seamless integration with existing Agent OS installation process

