### PR TITLE
fixed project install compatability issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Agent OS will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2025-10-08
+
+### Fixed
+
+#### Installation Script Compatibility Issues
+
+Fixed bugs in the project installation scripts (`project-install.sh`, `project-update.sh`, and `common-functions.sh`) that caused installations to fail in certain bash environments. These issues were triggered by stricter bash implementations and configurations, particularly when `set -e` (exit on error) was enabled.
+
 ## [2.0.0] - 2025-10-07
 
 Agent OS 2.0 is a major new release that brings several core architectural changes and improvements.

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -638,11 +638,11 @@ get_profile_files() {
         fi
 
         if [[ -d "$search_dir" ]]; then
-            find "$search_dir" -type f -name "*.md" -o -name "*.yml" -o -name "*.yaml" 2>/dev/null | while read file; do
-                local relative_path="${file#$profile_dir/}"
+            find "$search_dir" -type f \( -name "*.md" -o -name "*.yml" -o -name "*.yaml" \) 2>/dev/null | while read file; do
+                relative_path="${file#$profile_dir/}"
 
                 # Check if excluded
-                local excluded="false"
+                excluded="false"
                 echo "$excluded_patterns" | while read pattern; do
                     if [[ -n "$pattern" ]] && match_pattern "$relative_path" "$pattern"; then
                         excluded="true"

--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -180,7 +180,7 @@ install_standards() {
                 local installed_file=$(copy_file "$source" "$dest")
                 if [[ -n "$installed_file" ]]; then
                     INSTALLED_FILES+=("$installed_file")
-                    ((standards_count++))
+                    ((standards_count++)) || true
                 fi
             fi
         fi
@@ -210,7 +210,7 @@ install_roles() {
                 local installed_file=$(copy_file "$source" "$dest")
                 if [[ -n "$installed_file" ]]; then
                     INSTALLED_FILES+=("$installed_file")
-                    ((roles_count++))
+                    ((roles_count++)) || true
                 fi
             fi
         fi
@@ -252,7 +252,7 @@ install_single_agent_commands() {
                 if [[ "$DRY_RUN" == "true" ]]; then
                     INSTALLED_FILES+=("$dest")
                 fi
-                ((commands_count++))
+                ((commands_count++)) || true
             fi
         fi
     done < <(get_profile_files "$EFFECTIVE_PROFILE" "$BASE_DIR" "commands")
@@ -268,7 +268,7 @@ install_single_agent_commands() {
                     if [[ "$DRY_RUN" == "true" ]]; then
                         INSTALLED_FILES+=("$dest")
                     fi
-                    ((commands_count++))
+                    ((commands_count++)) || true
                 fi
             fi
         done < <(get_profile_files "$EFFECTIVE_PROFILE" "$BASE_DIR" "commands")
@@ -303,7 +303,7 @@ install_claude_code_files() {
                 if [[ "$DRY_RUN" == "true" ]]; then
                     INSTALLED_FILES+=("$dest")
                 fi
-                ((commands_count++))
+                ((commands_count++)) || true
             fi
         fi
     done < <(get_profile_files "$EFFECTIVE_PROFILE" "$BASE_DIR" "commands")
@@ -326,7 +326,7 @@ install_claude_code_files() {
                 if [[ "$DRY_RUN" == "true" ]]; then
                     INSTALLED_FILES+=("$dest")
                 fi
-                ((agents_count++))
+                ((agents_count++)) || true
             fi
         fi
     done
@@ -343,7 +343,7 @@ install_claude_code_files() {
                 if [[ "$DRY_RUN" == "true" ]]; then
                     INSTALLED_FILES+=("$dest")
                 fi
-                ((agents_count++))
+                ((agents_count++)) || true
             fi
         fi
     done
@@ -397,7 +397,7 @@ install_claude_code_files() {
                 if [[ "$DRY_RUN" == "true" ]]; then
                     INSTALLED_FILES+=("$dest")
                 fi
-                ((agents_count++))
+                ((agents_count++)) || true
             done
         fi
     fi
@@ -451,7 +451,7 @@ install_claude_code_files() {
                 if [[ "$DRY_RUN" == "true" ]]; then
                     INSTALLED_FILES+=("$dest")
                 fi
-                ((agents_count++))
+                ((agents_count++)) || true
             done
         fi
     fi

--- a/scripts/project-update.sh
+++ b/scripts/project-update.sh
@@ -341,16 +341,16 @@ update_standards() {
             if [[ -f "$source" ]]; then
                 if should_skip_file "$dest" "$OVERWRITE_ALL" "$OVERWRITE_STANDARDS" "standard"; then
                     SKIPPED_FILES+=("$dest")
-                    ((standards_skipped++))
+                    ((standards_skipped++)) || true
                     print_verbose "Skipped: $dest"
                 else
                     if [[ -f "$dest" ]]; then
                         UPDATED_FILES+=("$dest")
-                        ((standards_updated++))
+                        ((standards_updated++)) || true
                         print_verbose "Updated: $dest"
                     else
                         NEW_FILES+=("$dest")
-                        ((standards_new++))
+                        ((standards_new++)) || true
                         print_verbose "New file: $dest"
                     fi
                     if [[ "$DRY_RUN" != "true" ]]; then
@@ -390,16 +390,16 @@ update_roles() {
             if [[ -f "$source" ]]; then
                 if should_skip_file "$dest" "$OVERWRITE_ALL" "false" "role"; then
                     SKIPPED_FILES+=("$dest")
-                    ((roles_skipped++))
+                    ((roles_skipped++)) || true
                     print_verbose "Skipped: $dest"
                 else
                     if [[ -f "$dest" ]]; then
                         UPDATED_FILES+=("$dest")
-                        ((roles_updated++))
+                        ((roles_updated++)) || true
                         print_verbose "Updated: $dest"
                     else
                         NEW_FILES+=("$dest")
-                        ((roles_new++))
+                        ((roles_new++)) || true
                         print_verbose "New file: $dest"
                     fi
                     if [[ "$DRY_RUN" != "true" ]]; then
@@ -448,16 +448,16 @@ update_single_agent_commands() {
 
                 if should_skip_file "$dest" "$OVERWRITE_ALL" "$OVERWRITE_COMMANDS" "command"; then
                     SKIPPED_FILES+=("$dest")
-                    ((commands_skipped++))
+                    ((commands_skipped++)) || true
                     print_verbose "Skipped: $dest"
                 else
                     if [[ -f "$dest" ]]; then
                         UPDATED_FILES+=("$dest")
-                        ((commands_updated++))
+                        ((commands_updated++)) || true
                         print_verbose "Updated: $dest"
                     else
                         NEW_FILES+=("$dest")
-                        ((commands_new++))
+                        ((commands_new++)) || true
                         print_verbose "New file: $dest"
                     fi
                     if [[ "$DRY_RUN" != "true" ]]; then
@@ -478,16 +478,16 @@ update_single_agent_commands() {
 
                     if should_skip_file "$dest" "$OVERWRITE_ALL" "$OVERWRITE_COMMANDS" "command"; then
                         SKIPPED_FILES+=("$dest")
-                        ((commands_skipped++))
+                        ((commands_skipped++)) || true
                         print_verbose "Skipped: $dest"
                     else
                         if [[ -f "$dest" ]]; then
                             UPDATED_FILES+=("$dest")
-                            ((commands_updated++))
+                            ((commands_updated++)) || true
                             print_verbose "Updated: $dest"
                         else
                             NEW_FILES+=("$dest")
-                            ((commands_new++))
+                            ((commands_new++)) || true
                             print_verbose "New file: $dest"
                         fi
                         if [[ "$DRY_RUN" != "true" ]]; then
@@ -533,16 +533,16 @@ update_claude_code_files() {
 
                 if should_skip_file "$dest" "$OVERWRITE_ALL" "$OVERWRITE_COMMANDS" "command"; then
                     SKIPPED_FILES+=("$dest")
-                    ((commands_skipped++))
+                    ((commands_skipped++)) || true
                     print_verbose "Skipped: $dest"
                 else
                     if [[ -f "$dest" ]]; then
                         UPDATED_FILES+=("$dest")
-                        ((commands_updated++))
+                        ((commands_updated++)) || true
                         print_verbose "Updated: $dest"
                     else
                         NEW_FILES+=("$dest")
-                        ((commands_new++))
+                        ((commands_new++)) || true
                         print_verbose "New file: $dest"
                     fi
                     if [[ "$DRY_RUN" != "true" ]]; then
@@ -731,15 +731,15 @@ update_claude_code_files() {
         local commands_actual_new=0
 
         for file in "${UPDATED_FILES[@]}"; do
-            [[ "$file" == *"$command_pattern"* ]] && ((commands_actual_updated++))
+            [[ "$file" == *"$command_pattern"* ]] && ((commands_actual_updated++)) || true
         done
 
         for file in "${NEW_FILES[@]}"; do
-            [[ "$file" == *"$command_pattern"* ]] && ((commands_actual_new++))
+            [[ "$file" == *"$command_pattern"* ]] && ((commands_actual_new++)) || true
         done
 
         for file in "${SKIPPED_FILES[@]}"; do
-            [[ "$file" == *"$command_pattern"* ]] && ((commands_actual_skipped++))
+            [[ "$file" == *"$command_pattern"* ]] && ((commands_actual_skipped++)) || true
         done
 
         if [[ $commands_actual_new -gt 0 ]]; then
@@ -759,15 +759,15 @@ update_claude_code_files() {
         local agents_new=0
 
         for file in "${UPDATED_FILES[@]}"; do
-            [[ "$file" == *"$agent_pattern"* ]] && ((agents_updated++))
+            [[ "$file" == *"$agent_pattern"* ]] && ((agents_updated++)) || true
         done
 
         for file in "${NEW_FILES[@]}"; do
-            [[ "$file" == *"$agent_pattern"* ]] && ((agents_new++))
+            [[ "$file" == *"$agent_pattern"* ]] && ((agents_new++)) || true
         done
 
         for file in "${SKIPPED_FILES[@]}"; do
-            [[ "$file" == *"$agent_pattern"* ]] && ((agents_skipped++))
+            [[ "$file" == *"$agent_pattern"* ]] && ((agents_skipped++)) || true
         done
 
         if [[ $agents_new -gt 0 ]]; then


### PR DESCRIPTION
Fixed bugs in the project installation scripts (`project-install.sh`, `project-update.sh`, and `common-functions.sh`) that caused installations to fail in certain bash environments. These issues were triggered by stricter bash implementations and configurations, particularly when `set -e` (exit on error) was enabled.