### PR TITLE
Update default path for standards after a fresh install

### DIFF
--- a/scripts/base-install.sh
+++ b/scripts/base-install.sh
@@ -496,7 +496,7 @@ perform_fresh_installation() {
     echo ""
     echo -e "${GREEN}Next steps:${NC}"
     echo ""
-    echo -e "${GREEN}1) Customize your profile's standards in ~/agent-os/standards${NC}"
+    echo -e "${GREEN}1) Customize your profile's standards in ~/agent-os/profiles/default/standards${NC}"
     echo ""
     echo -e "${GREEN}2) Navigate to a project directory${NC}"
     echo -e "   ${YELLOW}cd path/to/project-directory${NC}"


### PR DESCRIPTION
## Summary
I did a fresh install of AgentOS v2 and realized the info provided by the install script output was outdated.
