### PR TITLE
Add --pro-user flag: enforce Sonnet for Claude Code Pro users

### DIFF
--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -31,6 +31,7 @@ OVERWRITE_ALL="false"
 OVERWRITE_STANDARDS="false"
 OVERWRITE_COMMANDS="false"
 OVERWRITE_AGENTS="false"
+PRO_USER="false"
 INSTALLED_FILES=()
 
 # -----------------------------------------------------------------------------
@@ -54,6 +55,7 @@ Options:
     --overwrite-standards       Overwrite existing standards during update
     --overwrite-commands        Overwrite existing commands during update
     --overwrite-agents          Overwrite existing agents during update
+    --pro-user                  Replace "opus" with "sonnet" in specific agent files
     --dry-run                   Show what would be done without doing it
     --verbose                   Show detailed output
     -h, --help                  Show this help message
@@ -113,6 +115,10 @@ parse_arguments() {
                 ;;
             --overwrite-agents)
                 OVERWRITE_AGENTS="true"
+                shift
+                ;;
+            --pro-user)
+                PRO_USER="true"
                 shift
                 ;;
             --dry-run)
@@ -373,6 +379,10 @@ install_claude_code_files() {
                 role_data="${role_data}<<<tools>>>"$'\n'"$tools"$'\n'"<<<END>>>"$'\n'
 
                 local model=$(parse_role_yaml "$implementers_file" "implementers" "$id" "model")
+                # Override model if pro-user flag is enabled
+                if [[ "$PRO_USER" == "true" ]]; then
+                    model="sonnet"
+                fi
                 role_data="${role_data}<<<model>>>"$'\n'"$model"$'\n'"<<<END>>>"$'\n'
 
                 local color=$(parse_role_yaml "$implementers_file" "implementers" "$id" "color")
@@ -506,6 +516,9 @@ perform_installation() {
     echo -e "  Single-agent mode: ${YELLOW}$EFFECTIVE_SINGLE_AGENT_MODE${NC}"
     if [[ "$EFFECTIVE_SINGLE_AGENT_MODE" == "true" ]]; then
         echo -e "  Single-agent tool: ${YELLOW}$EFFECTIVE_SINGLE_AGENT_TOOL${NC}"
+    fi
+    if [[ "$PRO_USER" == "true" ]]; then
+        echo -e "  Pro user mode: ${YELLOW}enabled (opus → sonnet)${NC}"
     fi
     echo ""
 

--- a/scripts/project-update.sh
+++ b/scripts/project-update.sh
@@ -31,6 +31,7 @@ OVERWRITE_ALL="false"
 OVERWRITE_AGENTS="false"
 OVERWRITE_COMMANDS="false"
 OVERWRITE_STANDARDS="false"
+PRO_USER="false"
 SKIPPED_FILES=()
 UPDATED_FILES=()
 NEW_FILES=()
@@ -56,6 +57,7 @@ Options:
     --overwrite-agents          Overwrite existing agent files
     --overwrite-commands        Overwrite existing command files
     --overwrite-standards       Overwrite existing standards files
+    --pro-user                  Replace "opus" with "sonnet" in specific agent files
     --dry-run                   Show what would be done without doing it
     --verbose                   Show detailed output
     -h, --help                  Show this help message
@@ -115,6 +117,10 @@ parse_arguments() {
                 ;;
             --overwrite-standards)
                 OVERWRITE_STANDARDS="true"
+                shift
+                ;;
+            --pro-user)
+                PRO_USER="true"
                 shift
                 ;;
             --dry-run)
@@ -637,6 +643,10 @@ update_claude_code_files() {
                     role_data="${role_data}<<<tools>>>"$'\n'"$tools"$'\n'"<<<END>>>"$'\n'
 
                     local model=$(parse_role_yaml "$implementers_file" "implementers" "$id" "model")
+                    # Override model if pro-user flag is enabled
+                    if [[ "$PRO_USER" == "true" ]]; then
+                        model="sonnet"
+                    fi
                     role_data="${role_data}<<<model>>>"$'\n'"$model"$'\n'"<<<END>>>"$'\n'
 
                     local color=$(parse_role_yaml "$implementers_file" "implementers" "$id" "color")


### PR DESCRIPTION
* **Context:** Claude Code Pro users can only use Sonnet, not Opus.
* Adds a --pro-user flag to installer/updater:
   * Replaces _model: opus_ → _model: sonnet_ when copying these static agents:
       * implementation-verifier.md, product-planner.md, spec-researcher.md, spec-writer.md, tasks-list-creator.md, and roles/implementers.yml
   * Forces all generated implementer agents to _model: sonnet_ during compilation.
   * Updates help text and config output to reflect the flag.
* Keeps profile source templates unchanged; replacement happens at install/update time only.
### Why
* Ensures generated agents are compatible with Claude Code Pro (Sonnet-only).
### How to Use
```
./scripts/project-install.sh --pro-user
# or
./scripts/project-update.sh --overwrite-agents --pro-user
```
### Verification
* Generated .claude/agents/agent-os/*.md show model: sonnet for both static agents and implementers.
