### PR TITLE
fix: make AWK patterns flexible for YAML indentation

### DIFF
--- a/scripts/create-role.sh
+++ b/scripts/create-role.sh
@@ -500,7 +500,7 @@ select_verifiers() {
     fi
 
     # Extract verifier IDs
-    local verifier_ids=($(awk '/^  - id:/ {print $3}' "$verifiers_file"))
+    local verifier_ids=($(awk '/^[ \t]*- id:/ {print $3}' "$verifiers_file"))
 
     if [[ ${#verifier_ids[@]} -eq 0 ]]; then
         print_verbose "No verifiers defined, skipping verifier selection"

--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -354,7 +354,7 @@ install_claude_code_files() {
         local template_file=$(get_profile_file "$EFFECTIVE_PROFILE" "agents/templates/implementer.md" "$BASE_DIR")
         if [[ -f "$template_file" ]]; then
             # Get list of implementer IDs
-            local implementer_ids=$(awk '/^  - id:/ {print $3}' "$implementers_file")
+            local implementer_ids=$(awk '/^[ \t]*- id:/ {print $3}' "$implementers_file")
 
             for id in $implementer_ids; do
                 print_verbose "Generating implementer agent: $id"
@@ -408,7 +408,7 @@ install_claude_code_files() {
         local template_file=$(get_profile_file "$EFFECTIVE_PROFILE" "agents/templates/verifier.md" "$BASE_DIR")
         if [[ -f "$template_file" ]]; then
             # Get list of verifier IDs
-            local verifier_ids=$(awk '/^  - id:/ {print $3}' "$verifiers_file")
+            local verifier_ids=$(awk '/^[ \t]*- id:/ {print $3}' "$verifiers_file")
 
             for id in $verifier_ids; do
                 print_verbose "Generating area verifier agent: $id"

--- a/scripts/project-update.sh
+++ b/scripts/project-update.sh
@@ -612,7 +612,7 @@ update_claude_code_files() {
     if [[ -f "$implementers_file" ]]; then
         local template_file=$(get_profile_file "$PROJECT_PROFILE" "agents/templates/implementer.md" "$BASE_DIR")
         if [[ -f "$template_file" ]]; then
-            local implementer_ids=$(awk '/^  - id:/ {print $3}' "$implementers_file")
+            local implementer_ids=$(awk '/^[ \t]*- id:/ {print $3}' "$implementers_file")
 
             for id in $implementer_ids; do
                 print_verbose "Updating implementer agent: $id"
@@ -676,7 +676,7 @@ update_claude_code_files() {
     if [[ -f "$verifiers_file" ]]; then
         local template_file=$(get_profile_file "$PROJECT_PROFILE" "agents/templates/verifier.md" "$BASE_DIR")
         if [[ -f "$template_file" ]]; then
-            local verifier_ids=$(awk '/^  - id:/ {print $3}' "$verifiers_file")
+            local verifier_ids=$(awk '/^[ \t]*- id:/ {print $3}' "$verifiers_file")
 
             for id in $verifier_ids; do
                 print_verbose "Updating area verifier agent: $id"


### PR DESCRIPTION
- Replace rigid '/^  - id:/' patterns with flexible '/^[ \t]*- id:/' patterns
- Allows scripts to work with any YAML indentation (2 spaces, 4 spaces, tabs, etc.)
- Fixes issue where implementer/verifier IDs were not extracted due to indentation mismatch
- Updated patterns in project-update.sh, project-install.sh, and create-role.sh



## Summary
Resolves empty string bug when parsing YAML files with 4-space indentation as different yaml formatters use different settings. 

## Linked item
N/A

## Checklist
- [x] Linked to related Issue/Discussion
- [x] Documented steps to test (below)
- [x] Drafted “how to use” docs (if this adds new behavior)
- [x] Backwards compatibility considered (notes if applicable)

## Documented steps to test
1. run `project-install.sh`
2. run `project-update.sh`
3. run `create-role.sh`