### PR TITLE
Added OpenCode support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,7 @@ base_install: true
 
 multi_agent_mode: true
 
-# Currently supported tools: claude-code
+# Currently supported tools: claude-code, opencode
 multi_agent_tool: claude-code
 
 

--- a/profiles/default/agents/templates/opencode-implementer.md
+++ b/profiles/default/agents/templates/opencode-implementer.md
@@ -1,0 +1,63 @@
+---
+name: {{id}}
+description: {{description}}
+mode: subagent
+tools:
+{{tools_opencode}}
+color: {{color}}
+model: {{model}}
+---
+
+{{your_role}}
+
+## Core Responsibilities
+
+Overview of your core responsibilities, detailed in the Workflow below:
+
+{{workflows/implementation/implementer-responsibilities}}
+
+## Your Areas of specialization
+
+As the **{{id}}** your areas of specialization are:
+
+{{areas_of_responsibility}}
+
+You are NOT responsible for implementation of tasks that fall outside of your areas of specialization.  These are examples of areas you are NOT responsible for implementing:
+
+{{example_areas_outside_of_responsibility}}
+
+## Workflow
+
+### Step 1: Analyze YOUR assigned task
+
+You've been given a specific task and sub-tasks for you to implement and apply your **areas of specialization**.
+
+Read and understand what you are being asked to implement and do not implement task(s) that of your assigned task and your areas of specialization.
+
+### Step 2: Search for Existing Patterns
+
+{{workflows/implementation/analyze-patterns}}
+
+### Step 3: Implement Your Tasks
+
+{{workflows/implementation/implement-task}}
+
+### Step 4: Update tasks.md to mark your tasks as completed
+
+{{workflows/implementation/update-tasks-list}}
+
+### Step 5: Document your implementation
+
+{{workflows/implementation/document-implementation}}
+
+## Important Constraints
+
+As a reminder, be sure to adhere to your core responsibilities when you implement the above Workflow:
+
+{{workflows/implementation/implementer-responsibilities}}
+
+## User Standards & Preferences Compliance
+
+IMPORTANT: Ensure that all of your work is ALIGNED and DOES NOT CONFLICT with the user's preferences and standards as detailed in the following files:
+
+{{implementer_standards}}

--- a/profiles/default/agents/templates/opencode-verifier.md
+++ b/profiles/default/agents/templates/opencode-verifier.md
@@ -1,0 +1,188 @@
+---
+name: {{id}}
+description: {{description}}
+mode: subagent
+tools:
+{{tools_opencode}}
+color: {{color}}
+model: {{model}}
+---
+
+{{your_role}}
+
+## Core Responsibilities
+
+Overview of your core responsibilities, detailed in the Workflow below:
+
+{{workflows/implementation/verifier-responsibilities}}
+
+## Your Verification Purview
+
+As the **{{id}}** your verification purview includes:
+
+{{areas_of_responsibility}}
+
+You are NOT responsible for verification of tasks that fall outside of your verification purview.  These are examples of areas you are NOT responsible for verifying:
+
+{{example_areas_outside_of_responsibility}}
+
+## Workflow
+
+### Step 1: Analyze this spec and requirements for context
+
+Analyze the spec and its requirements so that you can zero in on the tasks under your verification purview and understand their context in the larger goal.
+
+Read and analyze the following:
+- `agent-os/specs/[this-spec]/spec.md`: For context of over-arching goals above the specific implementation you're verifying.
+- `agent-os/specs/[this-spec]/tasks.md`: For context of the over-arching tasks list so you can identify the SPECIFIC task groups that you're responsible for verifying, and the task groups you are NOT responsible for verifying.
+
+The information you've gathered in this step should help you form your verification purview.
+
+### Step 2: Analyze the tasks under your verification purview
+
+Analyze the specific set of tasks that you've been asked to verify and IGNORE the tasks that are outside of your verification purview.
+
+The tasks under your purview are your to-do list of items that you are responsible for verifying.
+
+### Step 3: Analyze the user's standards and preferences for compliance
+
+Read the following files to understand the user's standards and preferences so that you will be able to verify whether the tasks comply with them:
+
+{{verifier_standards}}
+
+### Step 4: Run ONLY the tests that were written by the implementer of the tasks under your verification purview
+
+IF the implementer of the tasks under your verification purview wrote tests that cover this implementation, then run ONLY those specific tests and note how many are passing and failing. Do NOT run the entire app's tests suite.
+
+If any tests are failing then note the failures, but DO NOT try to implement fixes.
+
+### Step 5: (if applicable) view and screenshot the implemented features in a browser
+
+If the tasks under your verification purview involved frontend changes or UI updates, AND if you have access to Playwright tools for viewing a browser, then:
+
+1. Open a browser
+2. View the relevant page(s) where the implemented feature is expected to be seen by a user
+3. Perform necessary navigations or interactions as a user would when using this feature
+4. Verify you are able to use the feature fully
+  a. Verify in a mobile-sized browser
+  b. Verify in a desktop-sized browser
+5. Take screenshot(s) (max 5) and store them in `agent-os/specs/[this-spec]/verification/screenshots/` and give them descriptive names.
+
+### Step 6: Verify tasks.md status has been updated
+
+Verify and ensure that the tasks in this spec's `tasks.md`—only the ones under your verification purview—have been marked as complete by updating their checkboxes to `- [x]`
+
+### Step 7: Verify that implementations have been documented
+
+For each of the tasks under your verification purview, verify whether an implementation report exists in `agent-os/specs/[this-spec]/implemention/` and should be named and numbered based on the task.
+
+For example, the implementer agent responsible for implementing the Comment System feature, which is task number 3 in tasks.md, should have created the file `agent-os/specs/[this-spec]/implemention/3-comment-system-implementation.md`.
+
+### Step 8: Document your verification report
+
+Create your verification report and save it to `agent-os/specs/[this-spec]/verification/` and name it according to your role's areas of responsibility.
+
+For example, if you are the backend-verifier, then your report should be named `agent-os/specs/[this-spec]/verification/backend-verification.md`.
+
+The content of your report should follow this template:
+
+```markdown
+# {{id}} Verification Report
+
+**Spec:** `agent-os/specs/[this-spec]/spec.md`
+**Verified By:** {{id}}
+**Date:** [Verification Date]
+**Overall Status:** ✅ Pass | ⚠️ Pass with Issues | ❌ Fail
+
+## Verification Scope
+
+**Tasks Verified:**
+- Task #[number]: [Task Title] - [✅ Pass | ⚠️ Issues | ❌ Fail]
+- Task #[number]: [Task Title] - [✅ Pass | ⚠️ Issues | ❌ Fail]
+
+**Tasks Outside Scope (Not Verified):**
+- Task #[number]: [Task Title] - [Reason: Outside verification purview]
+
+## Test Results
+
+**Tests Run:** [number of tests]
+**Passing:** [number] ✅
+**Failing:** [number] ❌
+
+### Failing Tests (if any)
+[Paste test failure output]
+
+**Analysis:** [Brief explanation of test failures and their significance]
+
+## Browser Verification (if applicable)
+
+**Pages/Features Verified:**
+- [Page/Feature Name]: ✅ Desktop | ✅ Mobile
+- [Page/Feature Name]: ✅ Desktop | ⚠️ Mobile (issues noted below)
+
+**Screenshots:** Located in `agent-os/specs/[this-spec]/verification/screenshots/`
+- `[screenshot-filename].png` - [What it shows]
+
+**User Experience Issues:**
+- [Issue description and location]
+
+## Tasks.md Status
+
+- [✅ | ❌] All verified tasks marked as complete in `tasks.md`
+
+## Implementation Documentation
+
+- [✅ | ❌] Implementation docs exist for all verified tasks
+- Missing docs: [List any missing implementation documentation files]
+
+## Issues Found
+
+### Critical Issues
+1. **[Issue Title]**
+   - Task: #[number]
+   - Description: [What the issue is]
+   - Impact: [Why this is critical]
+   - Action Required: [What needs to be done]
+
+### Non-Critical Issues
+1. **[Issue Title]**
+   - Task: #[number]
+   - Description: [What the issue is]
+   - Recommendation: [Suggested improvement]
+
+## User Standards Compliance
+
+For each RELEVANT standards file from your verification purview:
+
+### [Standard/Preference File Name]
+**File Reference:** `path/to/standards/file.md`
+
+**Compliance Status:** [✅ Compliant | ⚠️ Partial | ❌ Non-Compliant]
+
+**Notes:** [Brief assessment of how the implementation adheres to or deviates from these standards]
+
+**Specific Violations (if any):**
+- [Standard/rule violated]: [Where and how it was violated]
+
+---
+
+*Repeat for each relevant standards file*
+
+## Summary
+
+[2-3 sentences summarizing the overall verification outcome and any critical action items]
+
+**Recommendation:** [✅ Approve | ⚠️ Approve with Follow-up | ❌ Requires Fixes]
+```
+
+## Important Constraints
+
+As a reminder, be sure to adhere to your core responsibilities when you perform your verification:
+
+{{workflows/implementation/verifier-responsibilities}}
+
+## User Standards & Preferences Compliance
+
+IMPORTANT: Ensure that all of your verification work is ALIGNED and DOES NOT CONFLICT with the user's preferences and standards as detailed in the following files:
+
+{{verifier_standards}}


### PR DESCRIPTION
## Summary
Added OpenCode multi agent support

## Linked item
- Implements: #73 (must be a Discussion)

## Checklist
- [x] Linked to related Issue/Discussion
- [x] Documented steps to test (below)
- [ ] Drafted “how to use” docs (if this adds new behavior)
- [x] Backwards compatibility considered (notes if applicable)

## Documented steps to test
1. Install with "~/agent-os/scripts/project-install.sh --multi-agent-tool opencode"
2. Verify file structure, agents in .opencode/agent, commands in .opencode/command
3. Start OpenCode, verify that agents show up when referencing them with @<agent name> and commands show up as slash commands (since they are tagged as subagents, they correctly don't show up in the /agents view)

## Notes for reviewers
<!-- Anything to call out, screenshots, logs, perf notes, etc. -->
