### PR TITLE
Added haiku as selectable model in create-role

### DIFF
--- a/scripts/create-role.sh
+++ b/scripts/create-role.sh
@@ -265,10 +265,11 @@ select_model() {
     echo ""
     echo "  1) Sonnet"
     echo "  2) Opus"
-    echo "  3) Inherit your current Claude Code model setting"
+    echo "  3) Haiku"
+    echo "  4) Inherit your current Claude Code model setting"
     echo ""
 
-    read -p "$(echo -e "${BLUE}Enter selection (1-3): ${NC}")" selection
+    read -p "$(echo -e "${BLUE}Enter selection (1-4): ${NC}")" selection
 
     case $selection in
         1)
@@ -280,6 +281,10 @@ select_model() {
             print_success "Selected model: Opus"
             ;;
         3)
+            ROLE_MODEL="haiku"
+            print_success "Selected model: Haiku"
+            ;;
+        4)
             ROLE_MODEL="inherit"
             print_success "Selected model: Inherit from Claude Code"
             ;;


### PR DESCRIPTION
## Summary
Adds haiku as a selectable model in create-role

## Linked item
- Implements: #222

## Checklist
- [x] Linked to related Issue/Discussion
- [x] Documented steps to test (below)
- [x] Backwards compatibility considered (notes if applicable)

## Documented steps to test
1. Run create-role.sh and go through all questions
2. When the script asks about model, haiku is now a choice.
3. When the script has finished, haiku is in the agent markdown, and when @-mentioning the agent and asking which model it runs, it replies with haiku.
