### PR TITLE
fix: scripts exit after post incrementing a variable set to 0 ((var++)

### DIFF
--- a/scripts/base-install.sh
+++ b/scripts/base-install.sh
@@ -217,7 +217,7 @@ download_all_files() {
             [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
 
             if download_file "$file_path" "$dest_file"; then
-                ((file_count++))
+                ((file_count++)) || true
                 print_verbose "  Downloaded: ${file_path}"
             else
                 print_verbose "  Failed to download: ${file_path}"
@@ -448,7 +448,7 @@ full_update() {
                 local dir_path=$(dirname "$dest_file")
                 [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
                 if download_file "$file_path" "$dest_file"; then
-                    ((file_count++))
+                    ((file_count++)) || true
                     print_verbose "  Downloaded: ${file_path}"
                 fi
             fi
@@ -469,7 +469,7 @@ full_update() {
                 local dir_path=$(dirname "$dest_file")
                 [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
                 if download_file "$file_path" "$dest_file"; then
-                    ((file_count++))
+                    ((file_count++)) || true
                     print_verbose "  Downloaded: ${file_path}"
                 fi
             fi
@@ -532,7 +532,7 @@ overwrite_profile() {
                 [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
 
                 if download_file "$file_path" "$dest_file"; then
-                    ((file_count++))
+                    ((file_count++)) || true
                     print_verbose "  Downloaded: ${file_path}"
                 fi
             fi
@@ -563,7 +563,7 @@ overwrite_scripts() {
                 [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
 
                 if download_file "$file_path" "$dest_file"; then
-                    ((file_count++))
+                    ((file_count++)) || true
                     print_verbose "  Downloaded: ${file_path}"
                 fi
             fi

--- a/scripts/create-profile.sh
+++ b/scripts/create-profile.sh
@@ -130,7 +130,7 @@ select_inheritance() {
         local index=2
         for profile in "${profiles[@]}"; do
             echo "  $index) $profile"
-            ((index++))
+            ((index++)) || true
         done
 
         echo ""
@@ -194,7 +194,7 @@ select_copy_source() {
         local index=2
         for profile in "${profiles[@]}"; do
             echo "  $index) $profile"
-            ((index++))
+            ((index++)) || true
         done
 
         echo ""

--- a/scripts/create-role.sh
+++ b/scripts/create-role.sh
@@ -99,7 +99,7 @@ select_profile() {
             else
                 echo "  $index) $profile"
             fi
-            ((index++))
+            ((index++)) || true
         done
 
         echo ""
@@ -423,7 +423,7 @@ select_standards() {
                 local relative_dir="${dir#$standards_dir/}"
                 items+=("${relative_dir}/*")
                 echo "  $index) ${relative_dir}/*"
-                ((index++))
+                ((index++)) || true
             done < <(find "$standards_dir" -type d -mindepth 1 -print0 | sort -z)
 
             # Find all files
@@ -432,7 +432,7 @@ select_standards() {
                 local relative_file="${file#$standards_dir/}"
                 items+=("$relative_file")
                 echo "  $index) $relative_file"
-                ((index++))
+                ((index++)) || true
             done < <(find "$standards_dir" -type f \( -name "*.md" -o -name "*.yml" -o -name "*.yaml" \) -print0 | sort -z)
             shopt -u nullglob
 
@@ -516,7 +516,7 @@ select_verifiers() {
     local index=1
     for vid in "${verifier_ids[@]}"; do
         echo "  $index) $vid"
-        ((index++))
+        ((index++)) || true
     done
 
     echo ""


### PR DESCRIPTION
## Summary
Fixes an issue where stricter bash environments will exit after post incrementing a variable.
This results on ending the base-install progress after copying the first profile file.
**NB**: I was experiencing this on Debian/buster

## Checklist
- [ ] Linked to related Issue/Discussion
- [ ] Documented steps to test (below)
- [ ] Drafted “how to use” docs (if this adds new behavior)
- [x] Backwards compatibility considered (notes if applicable)

## Documented steps to test
1. `curl -sSL https://github.com/punkch/agent-os/blob/bugfix/base-install-on-linux/scripts/base-install.sh | bash` or clone repo and then `cat path/to/base-install.sh | bash`
2. also changes create-role / create-profile, so these should work normally after project is updated.

## Notes for reviewers
Might not be the best fix as there are multiple ways to increment a variable in bash, but it works for me.

> ((expression)) The expression is evaluated according to the rules described below under ARITHMETIC EVALUATION. If the value of the expression is non-zero, the return status is 0; otherwise the return status is 1. This is exactly equivalent to let "expression".

The fix just makes it return status 0 if the value of the expression `((var++))` is 0. Which normally will return status 1 as per the bash manual. 

Link to a similar SO issue:
https://askubuntu.com/questions/1379923/increment-operator-does-not-work-on-a-variable-if-variable-is-set-to-0
