### PR TITLE
fix(scripts): early exit in scripts due to post increment ((var++))

### DIFF
--- a/scripts/base-install.sh
+++ b/scripts/base-install.sh
@@ -217,7 +217,7 @@ download_all_files() {
             [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
 
             if download_file "$file_path" "$dest_file"; then
-                ((file_count++))
+                ((file_count++)) || true
                 print_verbose "  Downloaded: ${file_path}"
             else
                 print_verbose "  Failed to download: ${file_path}"
@@ -448,7 +448,7 @@ full_update() {
                 local dir_path=$(dirname "$dest_file")
                 [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
                 if download_file "$file_path" "$dest_file"; then
-                    ((file_count++))
+                    ((file_count++)) || true
                     print_verbose "  Downloaded: ${file_path}"
                 fi
             fi
@@ -469,7 +469,7 @@ full_update() {
                 local dir_path=$(dirname "$dest_file")
                 [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
                 if download_file "$file_path" "$dest_file"; then
-                    ((file_count++))
+                    ((file_count++)) || true
                     print_verbose "  Downloaded: ${file_path}"
                 fi
             fi
@@ -532,7 +532,7 @@ overwrite_profile() {
                 [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
 
                 if download_file "$file_path" "$dest_file"; then
-                    ((file_count++))
+                    ((file_count++)) || true
                     print_verbose "  Downloaded: ${file_path}"
                 fi
             fi
@@ -563,7 +563,7 @@ overwrite_scripts() {
                 [[ -d "$dir_path" ]] || mkdir -p "$dir_path"
 
                 if download_file "$file_path" "$dest_file"; then
-                    ((file_count++))
+                    ((file_count++)) || true
                     print_verbose "  Downloaded: ${file_path}"
                 fi
             fi

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -515,7 +515,7 @@ process_conditionals() {
                 should_include=false
             fi
 
-            ((nesting_level++))
+            ((nesting_level++)) || true
             continue
         fi
 
@@ -550,7 +550,7 @@ process_conditionals() {
                 should_include=false
             fi
 
-            ((nesting_level++))
+            ((nesting_level++)) || true
             continue
         fi
 

--- a/scripts/create-profile.sh
+++ b/scripts/create-profile.sh
@@ -130,7 +130,7 @@ select_inheritance() {
         local index=2
         for profile in "${profiles[@]}"; do
             echo "  $index) $profile"
-            ((index++))
+            ((index++)) || true
         done
 
         echo ""
@@ -194,7 +194,7 @@ select_copy_source() {
         local index=2
         for profile in "${profiles[@]}"; do
             echo "  $index) $profile"
-            ((index++))
+            ((index++)) || true
         done
 
         echo ""


### PR DESCRIPTION
The issue in #225 was not resolved with v2.1 update, so sending a fresh PR over v.2.1

Problem summary:
When doing post-increment i.e. `((some_variable++))`, if some_variable is 0 - the expression within the double brackets will return the value and then increment some_variable. If the return value is 0, then the return status will be 1, which `set -e` will consider as error and the script execution will stop. This PR changes the occurences of `((some_variable++))` to `((some_variable++)) || true` so it always returns status 0 (as in some of the other scripts which had similar issue in the past). Another way to solve is is to do pre-increment `((++some_variable))` which should work fine unless some some_variable is -1, but the code will look cleaner.

> ((expression)) The expression is evaluated according to the rules described below under ARITHMETIC EVALUATION. If the value of the expression is non-zero, the return status is 0; otherwise the return status is 1. This is exactly equivalent to let "expression".
