### PR TITLE
[bug fix] Updates verification report file extension

### DIFF
--- a/profiles/default/workflows/implementation/verification/create-verification-report.md
+++ b/profiles/default/workflows/implementation/verification/create-verification-report.md
@@ -1,4 +1,4 @@
-Create your final verification report in `agent-os/specs/[this-spec]/verifications/final-verification.html`.
+Create your final verification report in `agent-os/specs/[this-spec]/verifications/final-verification.md`.
 
 The content of this report should follow this structure:
 


### PR DESCRIPTION
## Summary
Corrects the file extension in the verification report creation guide. It changes the expected file type from .html to .md, aligning it with the the format that is requested right after.

## Linked item
N/A (didn't manage to open an issue, not sure why)

## Checklist
- [ ] Linked to related Issue/Discussion
- [ ] Documented steps to test (below)
- [ ] Drafted “how to use” docs (if this adds new behavior)
- [ ] Backwards compatibility considered (notes if applicable)

## Documented steps to test
1. Run the 3-verify-implementation.md command
2. The final-verification is an .html file, not a .md file

