### PR TITLE
fix: add CLAUDE.md and skills reading instructions for subagents

### DIFF
--- a/profiles/default/agents/implementer.md
+++ b/profiles/default/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 description: Use proactively to implement a feature by following a given tasks.md for a spec.
-tools: Write, Read, Bash, WebFetch, Playwright
+tools: Write, Read, Bash, WebFetch, Playwright, Skill
 color: red
 model: inherit
 ---

--- a/profiles/default/agents/spec-shaper.md
+++ b/profiles/default/agents/spec-shaper.md
@@ -1,7 +1,7 @@
 ---
 name: spec-shaper
 description: Use proactively to gather detailed requirements through targeted questions and visual analysis
-tools: Write, Read, Bash, WebFetch
+tools: Write, Read, Bash, WebFetch, Skill
 color: blue
 model: inherit
 ---

--- a/profiles/default/agents/spec-verifier.md
+++ b/profiles/default/agents/spec-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: spec-verifier
 description: Use proactively to verify the spec and tasks list
-tools: Write, Read, Bash, WebFetch
+tools: Write, Read, Bash, WebFetch, Skill
 color: pink
 model: sonnet
 ---

--- a/profiles/default/agents/spec-writer.md
+++ b/profiles/default/agents/spec-writer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-writer
 description: Use proactively to create a detailed specification document for development
-tools: Write, Read, Bash, WebFetch
+tools: Write, Read, Bash, WebFetch, Skill
 color: purple
 model: inherit
 ---

--- a/profiles/default/agents/tasks-list-creator.md
+++ b/profiles/default/agents/tasks-list-creator.md
@@ -1,7 +1,7 @@
 ---
 name: task-list-creator
 description: Use proactively to create a detailed and strategic tasks list for development of a spec
-tools: Write, Read, Bash, WebFetch
+tools: Write, Read, Bash, WebFetch, Skill
 color: orange
 model: inherit
 ---


### PR DESCRIPTION
### Problem

When `standards_as_claude_code_skills: true` is set in `config.yml`, subagents (implementer, tasks-list-creator, spec-writer, etc.) lose access to project coding standards and CLAUDE.md instructions.

### Root Cause

According to [Claude Code subagents documentation](https://code.claude.com/docs/en/sub-agents), subagents receive:

- Custom system prompt (from the agent definition file)
- Configured tools (inherited or specified)
- Auto-loaded skills (**only if specified in `skills:` field**)
- Separate context window

**Critical findings:**

1. **CLAUDE.md is NOT inherited by subagents**
   - The [CLAUDE.md documentation](https://code.claude.com/docs/en/memory) states that memory files are "automatically loaded into Claude Code's context when launched"
   - However, there is **no mention** of subagents inheriting CLAUDE.md files
   - Subagents operate with their own separate context window

2. **Skills require explicit configuration**
   - [Subagents documentation](https://code.claude.com/docs/en/sub-agents) shows skills can be loaded via the `skills:` field in agent frontmatter:
     ```yaml
     ---
     name: example-agent
     skills: skill1, skill2  # Optional - skills to auto-load
     ---
     ```
   - Agent-os agents **do not include** the `skills:` field, so skills are never loaded

3. **Empty fallback in agent-os**
   - The `{{UNLESS standards_as_claude_code_skills}}` block is skipped when skills mode is enabled
   - There's no `{{IF standards_as_claude_code_skills}}` alternative

### Current Behavior

In agent files like `implementer.md`, standards are included conditionally:

```handlebars
{{UNLESS standards_as_claude_code_skills}}
## User Standards & Preferences Compliance

IMPORTANT: Ensure that the tasks list you create IS ALIGNED...

{{standards/*}}
{{ENDUNLESS standards_as_claude_code_skills}}
```

| `standards_as_claude_code_skills` | Result |
|-----------------------------------|--------|
| `false` | Standards embedded directly via `{{standards/*}}` ✅ |
| `true` | Entire block **skipped** — agent receives **nothing** ❌ |

### Impact

Subagents may:
- Use wrong commands (e.g., `npm test` instead of project-specific `make test`)
- Ignore project architecture patterns
- Write code that violates project conventions
- Miss critical instructions from CLAUDE.md

### Expected Behavior

When `standards_as_claude_code_skills: true`, subagents should either:

**Option A:** Be instructed to manually read relevant files:
1. `CLAUDE.md` (if exists) for project-specific instructions
2. `agent-os/standards/` files for coding standards
3. `.claude/skills/` files for detailed patterns

**Option B:** Include the `skills:` field in agent frontmatter to auto-load relevant skills (though this is challenging since skill names are project-specific)

### Affected Agents

- implementer.md
- tasks-list-creator.md
- spec-writer.md
- spec-shaper.md
- spec-verifier.md
- product-planner.md
- implementation-verifier.md

### Environment

- agent-os version: 2.1.1
- Profile: default (affects all profiles using this pattern)

### References

- [Subagents - Claude Code Docs](https://code.claude.com/docs/en/sub-agents) — documents subagent configuration including the `skills:` field for auto-loading skills
- [Memory (CLAUDE.md) - Claude Code Docs](https://code.claude.com/docs/en/memory) — documents how CLAUDE.md is loaded (no mention of subagent inheritance)