### PR TITLE
feat(agents): add task completion rules, skills discovery, and Edit tool

### DIFF
--- a/profiles/default/agents/implementation-verifier.md
+++ b/profiles/default/agents/implementation-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: implementation-verifier
 description: Use proactively to verify the end-to-end implementation of a spec
-tools: Write, Read, Edit, Bash, WebFetch, Playwright
+tools: Write, Read, Edit, Bash, WebFetch, Playwright, Skill
 color: green
 model: inherit
 ---

--- a/profiles/default/agents/implementation-verifier.md
+++ b/profiles/default/agents/implementation-verifier.md
@@ -1,7 +1,6 @@
 ---
 name: implementation-verifier
 description: Use proactively to verify the end-to-end implementation of a spec
-tools: Write, Read, Edit, Bash, WebFetch, Playwright, Skill
 color: green
 model: inherit
 ---

--- a/profiles/default/agents/implementation-verifier.md
+++ b/profiles/default/agents/implementation-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: implementation-verifier
 description: Use proactively to verify the end-to-end implementation of a spec
-tools: Write, Read, Bash, WebFetch, Playwright
+tools: Write, Read, Edit, Bash, WebFetch, Playwright
 color: green
 model: inherit
 ---

--- a/profiles/default/agents/implementer.md
+++ b/profiles/default/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 description: Use proactively to implement a feature by following a given tasks.md for a spec.
-tools: Write, Read, Bash, WebFetch, Playwright, Skill
+tools: Write, Read, Edit, Bash, WebFetch, Playwright, Skill
 color: red
 model: inherit
 ---

--- a/profiles/default/agents/implementer.md
+++ b/profiles/default/agents/implementer.md
@@ -1,7 +1,6 @@
 ---
 name: implementer
 description: Use proactively to implement a feature by following a given tasks.md for a spec.
-tools: Write, Read, Edit, Bash, WebFetch, Playwright, Skill
 color: red
 model: inherit
 ---

--- a/profiles/default/agents/product-planner.md
+++ b/profiles/default/agents/product-planner.md
@@ -1,7 +1,6 @@
 ---
 name: product-planner
 description: Use proactively to create product documentation including mission, and roadmap
-tools: Write, Read, Edit, Bash, WebFetch
 color: cyan
 model: inherit
 ---

--- a/profiles/default/agents/product-planner.md
+++ b/profiles/default/agents/product-planner.md
@@ -1,7 +1,7 @@
 ---
 name: product-planner
 description: Use proactively to create product documentation including mission, and roadmap
-tools: Write, Read, Bash, WebFetch
+tools: Write, Read, Edit, Bash, WebFetch
 color: cyan
 model: inherit
 ---

--- a/profiles/default/agents/spec-initializer.md
+++ b/profiles/default/agents/spec-initializer.md
@@ -1,7 +1,6 @@
 ---
 name: spec-initializer
 description: Use proactively to initialize spec folder and save raw idea
-tools: Write, Edit, Bash
 color: green
 model: sonnet
 ---

--- a/profiles/default/agents/spec-initializer.md
+++ b/profiles/default/agents/spec-initializer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-initializer
 description: Use proactively to initialize spec folder and save raw idea
-tools: Write, Bash
+tools: Write, Edit, Bash
 color: green
 model: sonnet
 ---

--- a/profiles/default/agents/spec-shaper.md
+++ b/profiles/default/agents/spec-shaper.md
@@ -1,7 +1,7 @@
 ---
 name: spec-shaper
 description: Use proactively to gather detailed requirements through targeted questions and visual analysis
-tools: Write, Read, Bash, WebFetch, Skill
+tools: Write, Read, Edit, Bash, WebFetch, Skill
 color: blue
 model: inherit
 ---

--- a/profiles/default/agents/spec-shaper.md
+++ b/profiles/default/agents/spec-shaper.md
@@ -1,7 +1,6 @@
 ---
 name: spec-shaper
 description: Use proactively to gather detailed requirements through targeted questions and visual analysis
-tools: Write, Read, Edit, Bash, WebFetch, Skill
 color: blue
 model: inherit
 ---

--- a/profiles/default/agents/spec-verifier.md
+++ b/profiles/default/agents/spec-verifier.md
@@ -1,7 +1,6 @@
 ---
 name: spec-verifier
 description: Use proactively to verify the spec and tasks list
-tools: Write, Read, Edit, Bash, WebFetch, Skill
 color: pink
 model: sonnet
 ---

--- a/profiles/default/agents/spec-verifier.md
+++ b/profiles/default/agents/spec-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: spec-verifier
 description: Use proactively to verify the spec and tasks list
-tools: Write, Read, Bash, WebFetch, Skill
+tools: Write, Read, Edit, Bash, WebFetch, Skill
 color: pink
 model: sonnet
 ---

--- a/profiles/default/agents/spec-writer.md
+++ b/profiles/default/agents/spec-writer.md
@@ -1,7 +1,6 @@
 ---
 name: spec-writer
 description: Use proactively to create a detailed specification document for development
-tools: Write, Read, Edit, Bash, WebFetch, Skill
 color: purple
 model: inherit
 ---

--- a/profiles/default/agents/spec-writer.md
+++ b/profiles/default/agents/spec-writer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-writer
 description: Use proactively to create a detailed specification document for development
-tools: Write, Read, Bash, WebFetch, Skill
+tools: Write, Read, Edit, Bash, WebFetch, Skill
 color: purple
 model: inherit
 ---

--- a/profiles/default/agents/tasks-list-creator.md
+++ b/profiles/default/agents/tasks-list-creator.md
@@ -1,7 +1,6 @@
 ---
 name: task-list-creator
 description: Use proactively to create a detailed and strategic tasks list for development of a spec
-tools: Write, Read, Edit, Bash, WebFetch, Skill
 color: orange
 model: inherit
 ---

--- a/profiles/default/agents/tasks-list-creator.md
+++ b/profiles/default/agents/tasks-list-creator.md
@@ -1,7 +1,7 @@
 ---
 name: task-list-creator
 description: Use proactively to create a detailed and strategic tasks list for development of a spec
-tools: Write, Read, Bash, WebFetch, Skill
+tools: Write, Read, Edit, Bash, WebFetch, Skill
 color: orange
 model: inherit
 ---

--- a/profiles/default/commands/implement-tasks/multi-agent/implement-tasks.md
+++ b/profiles/default/commands/implement-tasks/multi-agent/implement-tasks.md
@@ -3,7 +3,7 @@
 Now that we have a spec and tasks list ready for implementation, we will proceed with implementation of this spec by following this multi-phase process:
 
 PHASE 1: Determine which task group(s) from tasks.md should be implemented
-PHASE 2: Delegate implementation to the implementer subagent
+PHASE 2: Delegate implementation to implementer subagents (one per task group)
 PHASE 3: After ALL task groups have been implemented, delegate to implementation-verifier to produce the final verification report.
 
 Follow each of these phases and their individual workflows IN SEQUENCE:
@@ -14,7 +14,7 @@ Follow each of these phases and their individual workflows IN SEQUENCE:
 
 First, check if the user has already provided instructions about which task group(s) to implement.
 
-**If the user HAS provided instructions:** Proceed to PHASE 2 to delegate implementation of those specified task group(s) to the **implementer** subagent.
+**If the user HAS provided instructions:** Proceed to PHASE 2 to delegate implementation of those specified task group(s) to **implementer** subagents (one per task group).
 
 **If the user has NOT provided instructions:**
 
@@ -26,21 +26,38 @@ Should we proceed with implementation of all task groups in tasks.md?
 If not, then please specify which task(s) to implement.
 ```
 
-### PHASE 2: Delegate implementation to the implementer subagent
+### PHASE 2: Delegate implementation to implementer subagents
 
-Delegate to the **implementer** subagent to implement the specified task group(s):
+**CRITICAL: Spawn a SEPARATE implementer subagent for EACH task group.** Each subagent gets its own context window, enabling focused and effective implementation.
 
-Provide to the subagent:
-- The specific task group(s) from `agent-os/specs/[this-spec]/tasks.md` including the parent task, all sub-tasks, and any sub-bullet points
+**Execution strategy based on task group dependencies:**
+
+1. **Analyze dependencies** - Check for "Dependencies:" annotations in tasks.md for each task group
+2. **Independent task groups** (no dependencies, or all dependencies already completed): Launch their implementer subagents **IN PARALLEL** by issuing multiple Task tool calls in a single message
+3. **Dependent task groups**: Wait for the required dependency to complete before launching
+
+**For EACH task group, spawn a dedicated implementer subagent providing:**
+
+- **ONE specific task group** from `agent-os/specs/[this-spec]/tasks.md` (including the parent task, all sub-tasks, and any sub-bullet points)
 - The path to this spec's documentation: `agent-os/specs/[this-spec]/spec.md`
 - The path to this spec's requirements: `agent-os/specs/[this-spec]/planning/requirements.md`
 - The path to this spec's visuals (if any): `agent-os/specs/[this-spec]/planning/visuals`
 
-Instruct the subagent to:
+Instruct each subagent to:
 1. Analyze the provided spec.md, requirements.md, and visuals (if any)
 2. Analyze patterns in the codebase according to its built-in workflow
 3. Implement the assigned task group according to requirements and standards
 4. Update `agent-os/specs/[this-spec]/tasks.md` to mark completed tasks with `- [x]`
+
+**Example: Parallel execution**
+If Task Group 1 and Task Group 2 have no dependencies on each other, launch both implementer subagents in a single message:
+- Task tool call #1: implementer for Task Group 1
+- Task tool call #2: implementer for Task Group 2
+
+**Example: Sequential execution**
+If Task Group 3 depends on Task Group 1:
+1. Wait for Task Group 1 implementer to complete
+2. Then launch Task Group 3 implementer
 
 ### PHASE 3: Produce the final verification report
 

--- a/profiles/default/commands/improve-skills/improve-skills.md
+++ b/profiles/default/commands/improve-skills/improve-skills.md
@@ -25,7 +25,22 @@ Analyze and read the skill file to understand what it is, what it should be used
 - The Skill's name and file name.
 - The Skill.md contains a link that points to `agent_os/standards/...` — Follow that link and read its contents.
 
-### Step 3: Rewrite the Skill description
+### Step 3: Normalize the Skill name and rewrite the description
+
+#### 3.1: Convert the skill name to kebab-case
+
+Transform the `name` field in the frontmatter to kebab-case format:
+- Convert all letters to lowercase
+- Replace all whitespace characters (spaces, tabs) with a single hyphen
+- Collapse multiple consecutive spaces/hyphens into a single hyphen
+- Trim leading/trailing hyphens if present
+
+Example transformations:
+- `"API Standards"` → `"api-standards"`
+- `"Vue  Component   Guidelines"` → `"vue-component-guidelines"`
+- `"TypeScript Best Practices"` → `"typescript-best-practices"`
+
+#### 3.2: Rewrite the description
 
 The most important element of a skill.md file that impacts its discoverability and trigger-ability by Claude Code is the content we write in the `description` in the skill.md frontmatter.
 

--- a/profiles/default/commands/improve-skills/improve-skills.md
+++ b/profiles/default/commands/improve-skills/improve-skills.md
@@ -1,7 +1,5 @@
 I want you to help me improve the files that make up my Claude Code Skills by rewriting their descriptions so that they can be more readily discovered and used by Claude Code when it works on coding tasks.
 
-You can refer to the Claude Code documentation on the Skills feature here: https://docs.claude.com/en/docs/claude-code/skills
-
 All of the Skills in our project are located in `.claude/skills/`. Each Skill has its own folder and inside each Skill folder is a file called `SKILL.md`.
 
 LOOP through each `SKILL.md` file and FOR EACH use the following process to revise its content and improve it:
@@ -17,6 +15,130 @@ Before I proceed with improving your Claude Code Skills, can you confirm that yo
 
 If not, then please specify which Skills I should include or exclude.
 ```
+
+---
+
+## Skills Writing Reference
+
+Before improving skills, understand these key concepts:
+
+### Critical: Three-Phase Loading Model
+
+```
+Phase 1: YAML frontmatter cached for ALL skills
+    ↓
+Phase 2: SKILL.md loaded when model decides to use skill
+    ↓
+Phase 3: Related files loaded based on links + context
+```
+
+**Implications:**
+- `description` must contain trigger patterns (Phase 1 decision)
+- SKILL.md must be SHORT - loaded before full context known
+- Related files can be LONGER - loaded only when needed
+- Links must have context descriptions (when to load each file)
+
+### Supported YAML Frontmatter Fields
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `name` | auto | Identifier (lowercase, hyphens, max 64 chars) |
+| `description` | **yes** | **Critical for triggering.** Max 1024 chars |
+| `when_to_use` | no | Additional trigger guidance |
+| `allowed-tools` | no | Restrict available tools |
+
+### Unsupported Fields - REMOVE If Present
+
+These fields are **ignored** by Claude Code:
+- `tags` - not supported
+- `version` - not supported
+- `dependencies` - not supported
+
+### Description Patterns
+
+```yaml
+# Standard triggers - list scenarios:
+description: "Use when writing database queries, creating migrations, working with Prisma models"
+
+# Mandatory loading (always load):
+description: "MANDATORY: Project coding standards. Use for all code in this project"
+
+# Combined with when_to_use:
+description: "Database patterns and best practices"
+when_to_use: "When working with PostgreSQL, Prisma, or SQL queries"
+
+# File type triggers:
+description: "Tailwind CSS patterns. Use when writing .tsx, .vue, .css files with utility classes"
+
+# Comprehensive (recommended for max discoverability):
+description: "Write accessible React components. Use when creating .tsx files, implementing ARIA attributes, keyboard navigation, or fixing accessibility issues"
+```
+
+### Compactness Principle
+
+**Skills consume context window. Every character matters.**
+
+- Short, clear descriptions with triggers
+- Minimal SKILL.md content - only essentials
+- **Illustrative examples**: 3-5 lines max (showing concept)
+- **Reference patterns**: Can be longer if they provide copy-paste value
+- Link to supporting files for details
+
+### File Structure Options
+
+**Minimal:**
+```
+skill-name/
+└── SKILL.md
+```
+
+**With Supporting Files:**
+```
+skill-name/
+├── SKILL.md          # Overview + links (SHORT)
+├── REFERENCE.md      # Detailed info
+└── EXAMPLES.md       # Code examples
+```
+
+**Multi-topic (preferred for context efficiency):**
+```
+skill-name/
+├── SKILL.md              # Core rules + short illustrative examples
+├── EXAMPLES-QUERIES.md   # Examples for database queries
+├── EXAMPLES-MIGRATIONS.md # Examples for migrations
+└── EXAMPLES-MODELS.md    # Examples for models
+```
+
+### Quick Template
+
+```markdown
+---
+name: my-skill
+description: "Use when [specific trigger situations]"
+---
+
+# My Skill
+
+## When to use this skill
+
+- When writing or editing [file types]
+- When implementing [features]
+- When debugging [issues]
+
+## Purpose
+[One sentence]
+
+## Instructions
+1. Step one
+2. Step two
+
+## Example
+\`\`\`code
+// 3-5 lines max
+\`\`\`
+```
+
+---
 
 ### Step 2: Analyze what this Skill does
 
@@ -44,14 +166,45 @@ Example transformations:
 
 The most important element of a skill.md file that impacts its discoverability and trigger-ability by Claude Code is the content we write in the `description` in the skill.md frontmatter.
 
-Rewrite this description using the following guidelines:
+**Algorithm for maximum discoverability:**
 
-- The first sentence should clearly describe what this skill is. For example: "Write Tailwind CSS code and structure front-end UIs using Tailwind CSS utility classes."
-- The second sentence and subsequent sentences should clearly and directly describe multiple examples where and when this skill should be used.
-- The use case examples can include "When writing or editing [file types]" where [file types] can be a list of file extensions or types of files or components commonly found in software projects.
-- The use case examples can also include situations or areas or tools where using this skill should come into play.
-- The description text can be long. There is no maximum character or word limit.
-- Focus on adding examples where the skill SHOULD be used. Do not include instructions on when NOT to use a skill (our goal is for the Skill to be readily found and used frequently).
+1. **First sentence:** Clearly state what the skill does
+   ```
+   "Write Tailwind CSS code and structure front-end UIs using utility classes."
+   ```
+
+2. **Following sentences:** List specific trigger scenarios using these patterns:
+   - **File types:** "When writing or editing .tsx, .vue, .css files"
+   - **Situations:** "When creating forms, layouts, or responsive designs"
+   - **Tools/technologies:** "When using PostCSS, CSS-in-JS, or styled-components"
+   - **Actions:** "When debugging, optimizing, or refactoring [specific area]"
+
+**Key principle:** Focus ONLY on when to USE the skill.
+Never include when NOT to use - this reduces discoverability.
+
+**Longer descriptions are better:** More trigger scenarios = higher discoverability.
+Use the full 1024 chars if needed.
+
+**Good vs Bad Examples:**
+```yaml
+# Bad - too vague, won't trigger:
+description: "Helps with database"
+
+# Good - specific triggers:
+description: "Use when connecting to PostgreSQL/MySQL, writing queries, or debugging database issues"
+
+# Better - multiple trigger scenarios:
+description: "API documentation generator. Use when documenting REST endpoints, creating OpenAPI specs, writing JSDoc comments, or generating SDK documentation"
+```
+
+#### 3.3: Remove unsupported fields
+
+Check YAML frontmatter and REMOVE these fields if present:
+- `tags`
+- `version`
+- `dependencies`
+
+These fields are ignored by Claude Code and should be removed.
 
 ### Step 4: Insert a section for 'When to use this skill'
 
@@ -59,9 +212,11 @@ At the top of the content of skill.md, below the frontmatter, insert an H2 headi
 
 The use case examples can repeat the same one(s) listed in the description and/or expand on them.
 
+**Tip:** This section has no character limit (unlike description's 1024 chars), so you can expand on triggers mentioned in the description and add more specific scenarios.
+
 Example:
 ```markdown
-## When to use this skill:
+## When to use this skill
 
 - [Descriptive example A]
 - [Descriptive example B]
@@ -71,19 +226,30 @@ Example:
 
 ### Step 5: Advise the user on improving their skills further
 
-After revising ALL Skill.md files located in the project's `.claude/skills/` folder, display the following message to the user to advise them on how to improve their Claude Code Skills further:
+After revising ALL Skill.md files located in the project's `.claude/skills/` folder, display the following message to the user:
 
 ```
 All Claude Code Skills have been analyzed and revised!
 
-RECOMMENDATION 👉 Review and revise them further using these tips:
+## Quality Checklist
 
-- Make Skills as descriptive as possible
-- Use their 'description' frontmatter to tell Claude Code when it should proactively use this skill.
-- Include all relevant instructions, details and directives within the content of the Skill.
+Verify each skill meets these criteria:
+
+- [ ] `description` contains specific trigger patterns
+- [ ] Has "When to use this skill" section at top of content
+- [ ] No `tags`/`version`/`dependencies` fields (unsupported)
+- [ ] SKILL.md is SHORT (loaded early, before full context)
+- [ ] Illustrative examples are short (3-5 lines)
+- [ ] Links have context descriptions (when to load each file)
+- [ ] One skill = one capability (focused scope)
+
+## Additional Recommendations
+
+- **Compactness:** Skills consume context window. Every character matters.
+- **Triggering:** Description determines when skill loads - make it as specific as possible.
+- **Progressive disclosure:** SKILL.md loads first, supporting files only when needed.
+- **Multi-topic skills:** Split examples into separate files by topic for context efficiency.
+- **Content completeness:** Include all relevant instructions, details and directives within the content of the Skill.
 - You can link to other files (like your Agent OS standards files) using markdown links.
-- You can consolidate multiple similar skills into single skills where it makes sense for Claude to find and use them together.
-
-For more best practices, refer to the official Claude Code documentation on Skills:
-https://docs.claude.com/en/docs/claude-code/skills
+- Consolidate similar skills where it makes sense for Claude to find and use them together.
 ```

--- a/profiles/default/commands/improve-skills/improve-skills.md
+++ b/profiles/default/commands/improve-skills/improve-skills.md
@@ -42,7 +42,7 @@ Phase 3: Related files loaded based on links + context
 
 | Field | Required | Purpose |
 |-------|----------|---------|
-| `name` | auto | Identifier (lowercase, hyphens, max 64 chars) |
+| `name` | **yes** | Identifier (lowercase, hyphens, max 64 chars). Must match directory name. |
 | `description` | **yes** | **Critical for triggering.** Max 1024 chars |
 | `when_to_use` | no | Additional trigger guidance |
 | `allowed-tools` | no | Restrict available tools |

--- a/profiles/default/workflows/implementation/create-tasks-list.md
+++ b/profiles/default/workflows/implementation/create-tasks-list.md
@@ -3,9 +3,10 @@
 ## Core Responsibilities
 
 1. **Analyze spec and requirements**: Read and analyze the spec.md and/or requirements.md to inform the tasks list you will create.
-2. **Plan task execution order**: Break the requirements into a list of tasks in an order that takes their dependencies into account.
-3. **Group tasks by specialization**: Group tasks that require the same skill or stack specialization together (backend, api, ui design, etc.)
-4. **Create Tasks list**: Create the markdown tasks list broken into groups with sub-tasks.
+2. **Verify spec completeness**: For refactoring tasks, independently verify all affected code is covered in the spec.
+3. **Plan task execution order**: Break the requirements into a list of tasks in an order that takes their dependencies into account.
+4. **Group tasks by specialization**: Group tasks that require the same skill or stack specialization together (backend, api, ui design, etc.)
+5. **Create Tasks list**: Create the markdown tasks list broken into groups with sub-tasks.
 
 ## Workflow
 
@@ -17,6 +18,57 @@ Read each of these files (whichever are available) and analyze them to understan
 
 Use your learnings to inform the tasks list and groupings you will create in the next step.
 
+### Step 1.5: Verify Spec Completeness (for refactoring tasks)
+
+**CRITICAL:** Before creating tasks, verify the spec has identified ALL affected code. This prevents missing critical updates that could break the application.
+
+**When to perform verification:**
+- The spec involves modifying shared constants, types, or patterns
+- The spec involves renaming or changing values used across files
+- The spec mentions any kind of refactoring
+
+**How to verify:**
+
+1. **Identify key constants/types from the spec:**
+   Extract the main constants, types, or patterns being modified from the spec.
+
+2. **Run independent impact verification:**
+   ```bash
+   # For each constant/type being modified, search entire codebase
+   # Adjust for your project's file types
+   grep -r "CONSTANT_NAME" . | wc -l
+
+   # List unique directories with matches
+   grep -r "CONSTANT_NAME" . | cut -d':' -f1 | xargs -I{} dirname {} | sort -u
+   ```
+
+3. **Compare against spec:**
+   - Count files/packages mentioned in spec
+   - Compare with grep results
+   - If grep finds MORE files/packages than spec mentions, the spec may be INCOMPLETE
+
+4. **Check for duplicate definitions:**
+   ```bash
+   # Detect if same constant is defined in multiple places
+   grep -rn "CONSTANT_NAME" . | grep -E "(export|define|const|var|let|=)"
+   ```
+   If duplicates exist but aren't mentioned in spec, flag this.
+
+5. **If gaps found:**
+   - Document the missing files/packages discovered
+   - Create additional task groups to address them
+   - Include a note in tasks.md about the gaps found
+
+**Example gap documentation in tasks.md:**
+```markdown
+### Note: Additional Files Discovered
+
+During task creation, impact analysis found the following files not mentioned in spec:
+- `path/to/module/config.ext` - contains duplicate CONSTANT_NAME definition
+- `path/to/utils.ext` - hardcoded value 'xyz'
+
+These have been added as Task Group X.
+```
 
 ### Step 2: Create Tasks Breakdown
 
@@ -188,6 +240,8 @@ Recommended implementation sequence:
 ## Important Constraints
 
 - **Create tasks that are specific and verifiable**
+- **Verify spec completeness for refactoring tasks:** Run independent grep searches to find all affected files, not just those mentioned in spec
+- **Flag gaps discovered:** If your impact analysis finds files not in the spec, document them and create task groups to address them
 - **Group related tasks:** For example, group back-end engineering tasks together and front-end UI tasks together.
 - **Limit test writing during development**:
   - Each task group (1-3) should write 2-8 focused tests maximum

--- a/profiles/default/workflows/implementation/create-tasks-list.md
+++ b/profiles/default/workflows/implementation/create-tasks-list.md
@@ -237,6 +237,15 @@ Recommended implementation sequence:
 - Different execution order based on dependencies
 - More or fewer sub-tasks per group
 
+### Step 2.5: Review Project-Specific Guidelines
+
+Before finalizing the task list, check if the project has defined guidelines or skills (typically in `.claude/skills/` or similar locations). These may contain:
+- Critical requirements that must be included in acceptance criteria
+- Testing patterns and standards to follow
+- Architecture or coding conventions to enforce
+
+Reference applicable guidelines in task descriptions where they add value. This ensures implementers have access to project-specific guidance.
+
 ## Important Constraints
 
 - **Create tasks that are specific and verifiable**
@@ -251,3 +260,4 @@ Recommended implementation sequence:
 - **Use a focused test-driven approach** where each task group starts with writing 2-8 tests (x.1 sub-task) and ends with running ONLY those tests (final sub-task)
 - **Include acceptance criteria** for each task group
 - **Reference visual assets** if visuals are available
+- **NEVER defer functionality to "future"**: If a feature or capability is mentioned in the spec or requirements, it MUST be included in the task list. Do not mark items as "future feature", "out of scope for now", or similar unless the spec explicitly states this. If unclear whether something should be included, ask for clarification rather than deferring.

--- a/profiles/default/workflows/implementation/implement-tasks.md
+++ b/profiles/default/workflows/implementation/implement-tasks.md
@@ -12,8 +12,7 @@ Implement all tasks assigned to you and ONLY those task(s) that have been assign
 - **Specific notes provided in requirements.md, spec.md AND/OR tasks.md**
 - **Visuals provided (if any)** which would be located in `agent-os/specs/[this-spec]/planning/visuals/`
 - **CLAUDE.md** in the project root (if exists) - contains project-specific rules, conventions, and requirements that you MUST follow.
-- **Project skills** in `.claude/skills/` directory (if exists) - read and follow skills relevant to your task (e.g., testing skills when writing tests, frontend skills when writing UI code).
-- **Global skills** in `~/.claude/skills/` directory (if exists) - read and follow globally defined skills relevant to your task.
+- **Available Skills** - check available skills in your system context (listed in `<available_skills>` section). Use the `Skill(skill_name)` tool to invoke relevant skills for your task (e.g., testing skills when writing tests). Skills contain important requirements you MUST follow.
 - **User Standards & Preferences** which are defined below.
 
 ## Self-verify and test your work by:

--- a/profiles/default/workflows/implementation/implement-tasks.md
+++ b/profiles/default/workflows/implementation/implement-tasks.md
@@ -11,6 +11,9 @@ Implement all tasks assigned to you and ONLY those task(s) that have been assign
 - **The existing patterns** that you've found and analyzed in the codebase.
 - **Specific notes provided in requirements.md, spec.md AND/OR tasks.md**
 - **Visuals provided (if any)** which would be located in `agent-os/specs/[this-spec]/planning/visuals/`
+- **CLAUDE.md** in the project root (if exists) - contains project-specific rules, conventions, and requirements that you MUST follow.
+- **Project skills** in `.claude/skills/` directory (if exists) - read and follow skills relevant to your task (e.g., testing skills when writing tests, frontend skills when writing UI code).
+- **Global skills** in `~/.claude/skills/` directory (if exists) - read and follow globally defined skills relevant to your task.
 - **User Standards & Preferences** which are defined below.
 
 ## Self-verify and test your work by:
@@ -18,3 +21,44 @@ Implement all tasks assigned to you and ONLY those task(s) that have been assign
 - IF your task involves user-facing UI, and IF you have access to browser testing tools, open a browser and use the feature you've implemented as if you are a user to ensure a user can use the feature in the intended way.
   - Take screenshots of the views and UI elements you've tested and store those in `agent-os/specs/[this-spec]/verification/screenshots/`.  Do not store screenshots anywhere else in the codebase other than this location.
   - Analyze the screenshot(s) you've taken to check them against your current requirements.
+
+## CRITICAL: Task Completion Rules
+
+### Rule 1: A Task Is Complete ONLY When Actually Executed
+- If a task says "Run tests" - you MUST execute the tests and see the output
+- If a task says "Verify X works" - you MUST actually verify it
+- Do NOT mark tasks as complete based on intent or assumption
+- "I wrote the code" ≠ "task complete" - you must perform the actual action described
+
+### Rule 2: Handle Missing Prerequisites
+- If a task requires a running service (dev server, database) that is not running:
+  - Start the service yourself (safe for parallel execution in isolated environments)
+- If a task requires dependencies that are not installed:
+  - Do NOT install them yourself (may conflict with parallel agents)
+  - Report the blocker and keep task as `[ ]`
+  - Dependency installation is the responsibility of planning/setup phase
+- If you cannot determine how to proceed, ask the user for guidance
+
+### Rule 3: Parent Tasks Require All Subtasks Complete
+- A parent task (e.g., "5.0 Complete verification") can ONLY be marked `[x]` when ALL its subtasks are `[x]`
+- If subtasks 5.2, 5.3, 5.4 are `[ ]`, then 5.0 MUST remain `[ ]`
+- Never mark a parent task complete while leaving subtasks incomplete
+
+### Rule 4: TDD Phases Require Actual Test Execution
+- If tasks.md specifies TDD workflow:
+  - RED phase: Tests must be written AND executed to verify they fail
+  - GREEN phase: Tests must be executed AND pass
+- Do NOT mark TDD phases complete without actual test execution output
+
+### Rule 5: Verification Tasks Require Evidence
+- If a task says "Manual verification" or "Verify in browser":
+  - Actually perform the verification using available tools
+  - Take screenshots as evidence when possible
+  - Store evidence in the designated location (e.g., verification/screenshots/)
+- Do NOT mark verification tasks complete without performing verification
+
+### Rule 6: Incomplete Tasks Must Stay Incomplete
+- If you cannot complete a task after attempting to resolve blockers:
+  - Keep the task marked as `[ ]` (incomplete)
+  - Add a comment in tasks.md explaining what you tried and what blocked you
+  - NEVER mark a task `[x]` if you did not actually complete it

--- a/profiles/default/workflows/specification/research-spec.md
+++ b/profiles/default/workflows/specification/research-spec.md
@@ -74,6 +74,15 @@ Are there existing features in your codebase with similar patterns we should ref
 
 Please provide file/folder paths or names of these features if they exist.
 
+**Impact Analysis (for refactoring/modification tasks):**
+If this feature involves changing existing constants, types, or shared code, I need to identify ALL affected areas to avoid missing critical updates:
+
+- Are there any OTHER packages or modules that define or use the same constants/types?
+- Are there any hardcoded values in the codebase that should be updated?
+- Which areas beyond the obvious ones might be affected? (e.g., background jobs, utilities, tests, etc.)
+
+Please list any areas you know use the affected constants/types that I should investigate.
+
 **Visual Assets Request:**
 Do you have any design mockups, wireframes, or screenshots that could help guide the development?
 
@@ -182,6 +191,17 @@ Use the following structure and do not deviate from this structure when writing 
 [If user provided no similar features]
 No similar existing features identified for reference.
 
+### Impact Analysis
+[Based on user's response about affected areas - CRITICAL for refactoring tasks]
+
+**Affected Areas Identified by User:**
+- Package/Module: [Name] - Reason: [why it's affected]
+- Hardcoded values: [locations mentioned by user]
+- Additional areas: [other modules mentioned by user]
+
+[If user provided no impact information OR this is a new feature (not refactoring)]
+No additional impact areas identified. Note: spec-writer should still perform independent impact analysis.
+
 ### Follow-up Questions
 [If any were asked]
 
@@ -251,12 +271,15 @@ Ready for specification creation.
 ## Important Constraints
 
 - **MANDATORY**: Always run bash command to check visuals folder after receiving user answers
+- **MANDATORY**: Always ask about impact analysis for refactoring tasks - which other areas use the same constants/types
 - DO NOT write technical specifications for development. Just record your findings from information gathering to this single file: `[spec-path]/planning/requirements.md`.
 - Visual check is based on actual file(s) found via bash, NOT user statements
 - Check filenames for low-fidelity indicators and clarify design intent if found
 - Ask about existing similar features to promote code reuse
+- Ask about affected areas beyond obvious ones
 - Keep follow-ups minimal (1-3 questions max)
 - Save user's exact answers, not interpretations
 - Document all visual findings including fidelity level
 - Document paths to similar features for spec-writer to reference
+- Document all affected areas mentioned by user for spec-writer's impact analysis
 - OUTPUT questions and STOP to wait for orchestrator to relay responses

--- a/profiles/default/workflows/specification/write-spec.md
+++ b/profiles/default/workflows/specification/write-spec.md
@@ -85,10 +85,27 @@ Use appropriate search tools for the project's technology stack (grep, ripgrep, 
    grep -r "CONSTANT_NAME" . | cut -d':' -f1 | xargs -I{} dirname {} | sort -u
    ```
 
+5. **Find related mappings and transformations:**
+   ```bash
+   # Search for mapping structures that may reference the constants being changed
+   grep -rn "mapping\|Mapping\|MAP\|Map" .
+
+   # Search for transformation/conversion functions
+   grep -rn "transform\|Transform\|convert\|Convert\|to[A-Z]" .
+   ```
+
+   **Why this matters:** When changing constants or types, related data structures often need updates too:
+   - Lookup tables that map one value to another
+   - Configuration objects that use values from the constant
+   - Transformation functions that convert between formats
+
+   Review grep results for structures that reference or depend on the values being changed.
+
 **Document your findings:**
 - Total files affected (count)
 - Duplicate definitions found (these MUST be listed for consolidation)
 - Hardcoded values found (these MUST be listed for refactoring)
+- Related mappings/transformations found (these MUST be reviewed for updates)
 - All packages/modules requiring updates
 
 **Include in specification:** Add a "Files Requiring Modification" section OR expand "Existing Code to Leverage" to include all affected files, not just reusable ones.
@@ -144,7 +161,8 @@ Follow this structure exactly when creating the content of `spec.md`:
 1. **Always search for reusable code** before specifying new components
 2. **Always perform impact analysis** for refactoring tasks - find ALL affected files, not just similar ones
 3. **Check for duplicate definitions** - if the same constant/type exists in multiple packages, flag it for consolidation
-4. **Reference visual assets** when available
-5. **Do NOT write actual code** in the spec
-6. **Keep each section short**, with clear, direct, skimmable specifications
-7. **Do NOT deviate from the template above** and do not add additional sections
+4. **Check for related mappings** - search for lookup tables, transformations, and config objects that depend on the values being changed
+5. **Reference visual assets** when available
+6. **Do NOT write actual code** in the spec
+7. **Keep each section short**, with clear, direct, skimmable specifications
+8. **Do NOT deviate from the template above** and do not add additional sections

--- a/profiles/default/workflows/specification/write-spec.md
+++ b/profiles/default/workflows/specification/write-spec.md
@@ -166,3 +166,4 @@ Follow this structure exactly when creating the content of `spec.md`:
 6. **Do NOT write actual code** in the spec
 7. **Keep each section short**, with clear, direct, skimmable specifications
 8. **Do NOT deviate from the template above** and do not add additional sections
+9. **Ensure completeness for each user story**: For every user story, verify that all necessary artifacts (pages, endpoints, components, data structures) are explicitly listed in "Specific Requirements". If a user story implies functionality but doesn't specify how to implement it, either list the required artifacts or mark the ambiguity in "Out of Scope" with a note for clarification.

--- a/profiles/default/workflows/specification/write-spec.md
+++ b/profiles/default/workflows/specification/write-spec.md
@@ -4,7 +4,8 @@
 
 1. **Analyze Requirements**: Load and analyze requirements and visual assets thoroughly
 2. **Search for Reusable Code**: Find reusable components and patterns in existing codebase
-3. **Create Specification**: Write comprehensive specification document
+3. **Impact Analysis**: Find ALL code affected by this change (critical for refactoring)
+4. **Create Specification**: Write comprehensive specification document
 
 ## Workflow
 
@@ -43,6 +44,54 @@ Use appropriate search tools and commands for the project's technology stack to 
 - Architecture patterns already established
 
 Document your findings for use in the specification.
+
+### Step 2.5: Impact Analysis - Find All Affected Code
+
+**CRITICAL:** Before creating the specification, perform comprehensive impact analysis to find ALL code that will be affected by this change. This is especially important for refactoring tasks that modify shared constants, types, or patterns.
+
+**When to perform impact analysis:**
+- Modifying shared constants or type definitions
+- Renaming or changing values used across multiple files
+- Refactoring code that may have duplicates in different packages
+- Changing APIs, database schemas, or configuration formats
+
+**How to perform impact analysis:**
+
+Use appropriate search tools for the project's technology stack (grep, ripgrep, IDE search, etc.).
+
+1. **Search for constant/type usages:**
+   ```bash
+   # Find all files using the constants/types being modified
+   # Adjust file extensions for your project's language(s)
+   grep -r "CONSTANT_NAME" .
+   ```
+
+2. **Check for duplicate definitions:**
+   ```bash
+   # Detect if the same constant is defined in multiple places (this is a RED FLAG)
+   grep -rn "CONSTANT_NAME" . | grep -E "(export|define|const|var|let|=)"
+   ```
+   If duplicates are found, they MUST be consolidated in the spec.
+
+3. **Find hardcoded values:**
+   ```bash
+   # Search for hardcoded values that should use the constant
+   grep -rn "'literal_value'" .
+   ```
+
+4. **Identify all packages/modules affected:**
+   ```bash
+   # List unique directories with matches
+   grep -r "CONSTANT_NAME" . | cut -d':' -f1 | xargs -I{} dirname {} | sort -u
+   ```
+
+**Document your findings:**
+- Total files affected (count)
+- Duplicate definitions found (these MUST be listed for consolidation)
+- Hardcoded values found (these MUST be listed for refactoring)
+- All packages/modules requiring updates
+
+**Include in specification:** Add a "Files Requiring Modification" section OR expand "Existing Code to Leverage" to include all affected files, not just reusable ones.
 
 ### Step 3: Create Core Specification
 
@@ -93,7 +142,9 @@ Follow this structure exactly when creating the content of `spec.md`:
 ## Important Constraints
 
 1. **Always search for reusable code** before specifying new components
-2. **Reference visual assets** when available
-3. **Do NOT write actual code** in the spec
-4. **Keep each section short**, with clear, direct, skimmable specifications
-5. **Do NOT deviate from the template above** and do not add additional sections
+2. **Always perform impact analysis** for refactoring tasks - find ALL affected files, not just similar ones
+3. **Check for duplicate definitions** - if the same constant/type exists in multiple packages, flag it for consolidation
+4. **Reference visual assets** when available
+5. **Do NOT write actual code** in the spec
+6. **Keep each section short**, with clear, direct, skimmable specifications
+7. **Do NOT deviate from the template above** and do not add additional sections


### PR DESCRIPTION
## Summary

Add strict task completion rules, improve skills discovery, and enable full tool inheritance for all subagents. This prevents agents from falsely marking tasks as complete without actually executing them, aligns skills usage with Claude Code's built-in mechanisms, and gives subagents access to all tools including MCP servers.

## Linked item
- Closes: # (must be an open Issue) **OR**
- Implements: # (must be a Discussion)

## Checklist
- [ ] Linked to related Issue/Discussion
- [x] Documented steps to test (below)
- [x] Drafted "how to use" docs (if this adds new behavior)
- [x] Backwards compatibility considered (notes if applicable)

## Documented steps to test
1. Create a spec with tasks that include "Run tests" or "Verify in browser" requirements
2. Run implementer agent on the spec
3. Verify that implementer reads CLAUDE.md from project root
4. Verify that implementer uses `Skill(skill_name)` tool to invoke relevant skills from `<available_skills>` section
5. Verify that tasks requiring test execution are NOT marked complete without actual test output
6. Verify that parent tasks remain `[ ]` if any subtasks are incomplete
7. Verify that subagents have access to Edit tool and other inherited tools
8. Verify that subagents have access to MCP tools (e.g., Playwright, Context7) when configured

## Notes for reviewers

### Problem 1: False task completion

**Problem solved:**
Implementer agents were marking tasks as completed without actually executing them. For example:
- Tasks saying "Run E2E tests" were marked `[x]` without running tests
- Parent tasks marked complete while subtasks remained `[ ]`
- TDD GREEN phase marked complete without test execution output

**Root causes addressed:**
1. Implementer did not read CLAUDE.md (project-specific rules)
2. Implementer did not leverage available skills (may contain mandatory requirements like E2E testing)
3. No explicit rules about what constitutes task completion

**Changes:**

1. Added instruction to read CLAUDE.md from project root

2. Added instruction to use available skills via `Skill(skill_name)` tool
   - Initially added hardcoded paths (`.claude/skills/`, `~/.claude/skills/`)
   - Replaced with reference to `<available_skills>` section and `Skill()` tool
   - Reason: Claude Code already pre-loads skills as YAML frontmatter in system context, subagents inherit this context, so reading files manually is redundant

3. Added 6 critical task completion rules:
   - Rule 1: Tasks complete only when actually executed
   - Rule 2: Handle missing prerequisites (start services, but don't install deps)
   - Rule 3: Parent tasks require all subtasks complete
   - Rule 4: TDD phases require actual test execution
   - Rule 5: Verification tasks require evidence
   - Rule 6: Incomplete tasks must stay incomplete

### Problem 2: Limited tool access for subagents

**Problem solved:**
All agent files previously had explicit `tools:` field in their YAML frontmatter listing only specific tools (`Read`, `Write`, etc.). This restricted subagents to only those listed tools, preventing access to:
- **Edit tool** - for targeted string replacements
- **MCP tools** - Playwright, Context7, or any user-installed MCP servers
- **Future tools** - any new tools added to Claude Code

**Solution:**
Removed the `tools:` field entirely from all 8 agent files:
- `implementer.md`
- `spec-writer.md`
- `tasks-list-creator.md`
- `spec-shaper.md`
- `spec-verifier.md`
- `implementation-verifier.md`
- `product-planner.md`
- `spec-initializer.md`

**Rationale:**
Per Claude Code documentation: "Omit the tools field to inherit all tools from the main thread (default), including MCP tools." This approach:

1. **Enables full tool inheritance** - subagents automatically get all tools available to main Claude Code instance
2. **Includes MCP tools** - Playwright for browser automation, Context7 for docs, any user-configured MCP servers
3. **Zero maintenance** - new tools or MCP servers don't require updating agent files
4. **Edit tool now available** - subagents can use targeted string replacements instead of full file rewrites

### Backwards compatibility
- Fully backwards compatible
- Existing workflows continue to work
- New rules only add stricter validation, don't break existing behavior
- Rule 2 explicitly prevents dependency installation conflicts when running parallel agents
- Removing `tools:` field is additive - subagents gain access to more tools, not fewer

## References

Documentation sources used for these changes:

### Claude Code Tools Documentation

- **Frontmatter Reference** (tools/allowed-tools configuration):
  https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md

- **Agent Creator** (agent file structure with tools field):
  https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/agents/agent-creator.md

### Key Documentation Excerpts

From the agent creator documentation regarding tool inheritance:
> "Omit the tools field to inherit all tools from the main thread (default), including MCP tools"

This is the recommended approach for maximum flexibility, allowing subagents to access:
- All built-in Claude Code tools (Read, Write, Edit, Bash, Glob, Grep, etc.)
- All configured MCP server tools (Playwright, Context7, etc.)
- Any future tools without configuration changes
