### PR TITLE
Add Chrome tool alias for Claude in Chrome MCP tools

### DIFF
--- a/profiles/default/agents/implementation-verifier.md
+++ b/profiles/default/agents/implementation-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: implementation-verifier
 description: Use proactively to verify the end-to-end implementation of a spec
-tools: Write, Read, Bash, WebFetch, Playwright
+tools: Write, Read, Bash, WebFetch, Playwright, Chrome
 color: green
 model: inherit
 ---

--- a/profiles/default/agents/implementer.md
+++ b/profiles/default/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 description: Use proactively to implement a feature by following a given tasks.md for a spec.
-tools: Write, Read, Bash, WebFetch, Playwright, Skill
+tools: Write, Read, Bash, WebFetch, Playwright, Chrome, Skill
 color: red
 model: inherit
 ---

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -488,6 +488,15 @@ replace_playwright_tools() {
     echo "$tools" | sed "s/Playwright/$playwright_tools/g"
 }
 
+# Replace Chrome tool with expanded Claude in Chrome tool list
+replace_chrome_tools() {
+    local tools=$1
+
+    local chrome_tools="mcp__claude-in-chrome__javascript_tool, mcp__claude-in-chrome__read_page, mcp__claude-in-chrome__find, mcp__claude-in-chrome__form_input, mcp__claude-in-chrome__computer, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__resize_window, mcp__claude-in-chrome__gif_creator, mcp__claude-in-chrome__upload_image, mcp__claude-in-chrome__get_page_text, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__tabs_create_mcp, mcp__claude-in-chrome__update_plan, mcp__claude-in-chrome__read_console_messages, mcp__claude-in-chrome__read_network_requests, mcp__claude-in-chrome__shortcuts_list, mcp__claude-in-chrome__shortcuts_execute"
+
+    echo "$tools" | sed "s/Chrome/$chrome_tools/g"
+}
+
 # Process conditional compilation tags ({{IF}}, {{UNLESS}}, {{ENDIF}}, {{ENDUNLESS}})
 # Ignores {{orchestrated_standards}} and other placeholders
 process_conditionals() {
@@ -1023,6 +1032,13 @@ compile_agent() {
         local tools_line=$(echo "$content" | grep "^tools:")
         local new_tools_line=$(replace_playwright_tools "$tools_line")
         # Simple replacement since this is a single line
+        content=$(echo "$content" | sed "s|^tools:.*$|$new_tools_line|")
+    fi
+
+    # Replace Chrome in tools
+    if echo "$content" | grep -q "^tools:.*Chrome"; then
+        local tools_line=$(echo "$content" | grep "^tools:")
+        local new_tools_line=$(replace_chrome_tools "$tools_line")
         content=$(echo "$content" | sed "s|^tools:.*$|$new_tools_line|")
     fi
 


### PR DESCRIPTION
## Summary
- Add `Chrome` shorthand that expands to all 17 Claude in Chrome MCP tools during agent compilation
- Follows the same pattern as the existing `Playwright` alias

## Test plan
- [ ] Verify agents with `tools: Chrome` compile correctly
- [ ] Verify expansion includes all claude-in-chrome tools

Closes #300