### PR TITLE
Fixes 3.0 install not actually installing anything

### DIFF
--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -241,11 +241,11 @@ install_standards() {
             grep -v "^${relative_path}|" "$sources_file" > "${sources_file}.tmp" 2>/dev/null || true
             mv "${sources_file}.tmp" "$sources_file"
             echo "${relative_path}|${profile_name}" >> "$sources_file"
-            ((profile_file_count++))
+            ((++profile_file_count))
         done < <(find "$profile_standards" -name "*.md" -type f ! -path "*/.backups/*" -print0 2>/dev/null)
 
         if [[ "$profile_file_count" -gt 0 ]]; then
-            ((profiles_used++))
+            ((++profiles_used))
         fi
     done <<< "$INHERITANCE_CHAIN"
 
@@ -335,11 +335,11 @@ create_index() {
             local desc=$(get_existing_description "root" "$filename")
             if [[ -z "$desc" ]]; then
                 desc="Needs description - run /index-standards"
-                ((new_count++))
+                ((++new_count))
             fi
             echo "  $filename:" >> "$temp_file"
             echo "    description: $desc" >> "$temp_file"
-            ((entry_count++))
+            ((++entry_count))
         done <<< "$root_files"
         echo "" >> "$temp_file"
     fi
@@ -357,11 +357,11 @@ create_index() {
                 local desc=$(get_existing_description "$folder_name" "$filename")
                 if [[ -z "$desc" ]]; then
                     desc="Needs description - run /index-standards"
-                    ((new_count++))
+                    ((++new_count))
                 fi
                 echo "  $filename:" >> "$temp_file"
                 echo "    description: $desc" >> "$temp_file"
-                ((entry_count++))
+                ((++entry_count))
             done <<< "$md_files"
             echo "" >> "$temp_file"
         fi
@@ -399,7 +399,7 @@ install_commands() {
     for file in "$commands_source"/*.md; do
         if [[ -f "$file" ]]; then
             cp "$file" "$commands_dest/"
-            ((count++))
+            ((++count))
         fi
     done
 

--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -447,7 +447,7 @@ main() {
             done
             chain_display="$chain_display"$'\n'"$indent  ↳ inherits from: $profile_name"
         fi
-        ((chain_depth++))
+        ((++chain_depth))
     done <<< "$reversed_chain"
     echo "$chain_display"
 


### PR DESCRIPTION
## Summary
<!-- What does this change do and why? Keep it tight. -->
without this you get this issue where nothing actually happens on install
~/Repos/site$ ~/agent-os/scripts/project-install.sh

=== Agent OS Project Installation ===

The issue was a bash quirk:
((chain_depth++)) - post-increment returns the OLD value (0), which bash treats as "false" → exit code 1
((++chain_depth)) - pre-increment returns the NEW value (1), which bash treats as "true" → exit code 0
With set -e enabled, the script was dying on that line.



Configuration:

## Linked item

- Implements: #311 

## Checklist
- [x ] Linked to related Issue/Discussion
- [x] Documented steps to test (below)
- [ ] Drafted “how to use” docs (if this adds new behavior)
- [x] Backwards compatibility considered (notes if applicable)

## Documented steps to test
1. install new project 
2. with this change it installs agent-os
3.

## Notes for reviewers
thanks for all your great work
