### PR TITLE
Fix project-install.sh failing to copy standards

### DIFF
--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -221,7 +221,7 @@ install_standards() {
     while IFS= read -r profile_name; do
         [[ -z "$profile_name" ]] && continue
 
-        local profile_standards="$BASE_DIR/profiles/$profile_name/standards"
+        local profile_standards="$BASE_DIR/profiles/$profile_name"
 
         if [[ ! -d "$profile_standards" ]]; then
             continue
@@ -447,7 +447,7 @@ main() {
             done
             chain_display="$chain_display"$'\n'"$indent  ↳ inherits from: $profile_name"
         fi
-        ((chain_depth++))
+        ((chain_depth++)) || true
     done <<< "$reversed_chain"
     echo "$chain_display"
 


### PR DESCRIPTION
Two issues fixed:

1. Script looked for non-existent `standards/` subfolder in profiles. Profile structure is `profiles/<name>/<category>/<file>.md`, not `profiles/<name>/standards/<category>/<file>.md`.

2. Script crashed with `set -e` due to arithmetic expression returning exit code 1 when chain_depth was 0. Added `|| true` to prevent this.
