### PR TITLE
Fix arithmetic expression crash in project-install.sh

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -219,7 +219,7 @@ copy_standards() {
 
         ensure_dir "$(dirname "$dest_file")"
         cp "$file" "$dest_file"
-        ((count++))
+        ((++count))
     done < <(find "$source_dir" -name "*.md" -type f ! -path "*/.backups/*" -print0 2>/dev/null)
 
     echo "$count"

--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -241,11 +241,11 @@ install_standards() {
             grep -v "^${relative_path}|" "$sources_file" > "${sources_file}.tmp" 2>/dev/null || true
             mv "${sources_file}.tmp" "$sources_file"
             echo "${relative_path}|${profile_name}" >> "$sources_file"
-            ((profile_file_count++))
+            ((++profile_file_count))
         done < <(find "$profile_standards" -name "*.md" -type f ! -path "*/.backups/*" -print0 2>/dev/null)
 
         if [[ "$profile_file_count" -gt 0 ]]; then
-            ((profiles_used++))
+            ((++profiles_used))
         fi
     done <<< "$INHERITANCE_CHAIN"
 
@@ -335,11 +335,11 @@ create_index() {
             local desc=$(get_existing_description "root" "$filename")
             if [[ -z "$desc" ]]; then
                 desc="Needs description - run /index-standards"
-                ((new_count++))
+                ((++new_count))
             fi
             echo "  $filename:" >> "$temp_file"
             echo "    description: $desc" >> "$temp_file"
-            ((entry_count++))
+            ((++entry_count))
         done <<< "$root_files"
         echo "" >> "$temp_file"
     fi
@@ -357,11 +357,11 @@ create_index() {
                 local desc=$(get_existing_description "$folder_name" "$filename")
                 if [[ -z "$desc" ]]; then
                     desc="Needs description - run /index-standards"
-                    ((new_count++))
+                    ((++new_count))
                 fi
                 echo "  $filename:" >> "$temp_file"
                 echo "    description: $desc" >> "$temp_file"
-                ((entry_count++))
+                ((++entry_count))
             done <<< "$md_files"
             echo "" >> "$temp_file"
         fi
@@ -399,7 +399,7 @@ install_commands() {
     for file in "$commands_source"/*.md; do
         if [[ -f "$file" ]]; then
             cp "$file" "$commands_dest/"
-            ((count++))
+            ((++count))
         fi
     done
 

--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -447,7 +447,7 @@ main() {
             done
             chain_display="$chain_display"$'\n'"$indent  ↳ inherits from: $profile_name"
         fi
-        ((chain_depth++))
+        ((++chain_depth))
     done <<< "$reversed_chain"
     echo "$chain_display"
 

--- a/scripts/sync-to-profile.sh
+++ b/scripts/sync-to-profile.sh
@@ -449,7 +449,7 @@ backup_files() {
         if [[ -f "$source_file" ]]; then
             mkdir -p "$(dirname "$backup_file")"
             cp "$source_file" "$backup_file"
-            ((backup_count++))
+            ((++backup_count))
             print_verbose "Backed up: $file"
         fi
     done
@@ -477,7 +477,7 @@ execute_sync() {
 
         # Copy the file
         cp "$source_file" "$dest_file"
-        ((sync_count++))
+        ((++sync_count))
         print_verbose "Synced: $file"
     done
 


### PR DESCRIPTION
Fix arithmetic expression crash in project-install.sh

Script crashed with `set -e` due to post-increment returning exit code 1
when chain_depth was 0. Changed to pre-increment so expression always
returns non-zero value.

https://github.com/buildermethods/agent-os/discussions/311

