### PR TITLE
Fix "tac command not found" on macOS by using POSIX awk

### DIFF
--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -435,7 +435,7 @@ main() {
     local chain_depth=0
     local chain_display=""
     # Read chain in reverse order (from requested profile back to base) for display
-    local reversed_chain=$(echo "$INHERITANCE_CHAIN" | tac)
+    local reversed_chain=$(echo "$INHERITANCE_CHAIN" | awk '{a[NR]=$0} END{for(i=NR;i>=1;i--)print a[i]}')
     while IFS= read -r profile_name; do
         [[ -z "$profile_name" ]] && continue
         if [[ "$chain_depth" -eq 0 ]]; then


### PR DESCRIPTION
## Summary
  Replace `tac` with POSIX `awk` in `project-install.sh` to fix "command not found" error on macOS.

  ## Linked item
  - Closes: #

  ## Checklist
  - [x] Linked to related Issue/Discussion
  - [x] Documented steps to test (below)
  - [ ] Drafted "how to use" docs (if this adds new behavior)
  - [x] Backwards compatibility considered (notes if applicable)

  ## Documented steps to test
  1. Run `scripts/project-install.sh` on macOS — verify no "tac: command not found" error
  2. Run `scripts/project-install.sh` on Linux — verify behavior is unchanged
  3. Use a profile with inheritance and confirm the chain displays in the correct (reversed) order

  ## Notes for reviewers
  `tac` is a GNU coreutils utility not available on macOS by default. The replacement `awk '{a[NR]=$0} END{for(i=NR;i>=1;i--)print a[i]}'` is POSIX-compliant and works on both macOS and Linux. No behavioral change — output is identical.