### PR TITLE
Fix silent script failure from ((var++)) with set -e

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -219,7 +219,7 @@ copy_standards() {
 
         ensure_dir "$(dirname "$dest_file")"
         cp "$file" "$dest_file"
-        ((count++))
+        (( count++ )) || true
     done < <(find "$source_dir" -name "*.md" -type f ! -path "*/.backups/*" -print0 2>/dev/null)
 
     echo "$count"

--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -241,11 +241,11 @@ install_standards() {
             grep -v "^${relative_path}|" "$sources_file" > "${sources_file}.tmp" 2>/dev/null || true
             mv "${sources_file}.tmp" "$sources_file"
             echo "${relative_path}|${profile_name}" >> "$sources_file"
-            ((profile_file_count++))
+            (( profile_file_count++ )) || true
         done < <(find "$profile_standards" -name "*.md" -type f ! -path "*/.backups/*" -print0 2>/dev/null)
 
         if [[ "$profile_file_count" -gt 0 ]]; then
-            ((profiles_used++))
+            (( profiles_used++ )) || true
         fi
     done <<< "$INHERITANCE_CHAIN"
 
@@ -335,11 +335,11 @@ create_index() {
             local desc=$(get_existing_description "root" "$filename")
             if [[ -z "$desc" ]]; then
                 desc="Needs description - run /index-standards"
-                ((new_count++))
+                (( new_count++ )) || true
             fi
             echo "  $filename:" >> "$temp_file"
             echo "    description: $desc" >> "$temp_file"
-            ((entry_count++))
+            (( entry_count++ )) || true
         done <<< "$root_files"
         echo "" >> "$temp_file"
     fi
@@ -357,11 +357,11 @@ create_index() {
                 local desc=$(get_existing_description "$folder_name" "$filename")
                 if [[ -z "$desc" ]]; then
                     desc="Needs description - run /index-standards"
-                    ((new_count++))
+                    (( new_count++ )) || true
                 fi
                 echo "  $filename:" >> "$temp_file"
                 echo "    description: $desc" >> "$temp_file"
-                ((entry_count++))
+                (( entry_count++ )) || true
             done <<< "$md_files"
             echo "" >> "$temp_file"
         fi
@@ -399,7 +399,7 @@ install_commands() {
     for file in "$commands_source"/*.md; do
         if [[ -f "$file" ]]; then
             cp "$file" "$commands_dest/"
-            ((count++))
+            (( count++ )) || true
         fi
     done
 
@@ -447,7 +447,7 @@ main() {
             done
             chain_display="$chain_display"$'\n'"$indent  ↳ inherits from: $profile_name"
         fi
-        ((chain_depth++))
+        (( chain_depth++ )) || true
     done <<< "$reversed_chain"
     echo "$chain_display"
 

--- a/scripts/sync-to-profile.sh
+++ b/scripts/sync-to-profile.sh
@@ -194,7 +194,7 @@ select_profile() {
 
     for profile in "${profiles[@]}"; do
         echo "  $i) $profile"
-        ((i++))
+        (( i++ )) || true
     done
     echo "  $i) [Create new profile]"
     echo ""
@@ -273,7 +273,7 @@ select_files() {
             else
                 echo "  $i) [ ] $file"
             fi
-            ((i++))
+            (( i++ )) || true
         done
         echo ""
         echo ""
@@ -449,7 +449,7 @@ backup_files() {
         if [[ -f "$source_file" ]]; then
             mkdir -p "$(dirname "$backup_file")"
             cp "$source_file" "$backup_file"
-            ((backup_count++))
+            (( backup_count++ )) || true
             print_verbose "Backed up: $file"
         fi
     done
@@ -477,7 +477,7 @@ execute_sync() {
 
         # Copy the file
         cp "$source_file" "$dest_file"
-        ((sync_count++))
+        (( sync_count++ )) || true
         print_verbose "Synced: $file"
     done
 


### PR DESCRIPTION
## Summary

- `project-install.sh` silently exits after printing "Configuration:" without installing anything
- Root cause: bash `((var++))` returns exit status 1 when `var` is 0 (post-increment returns the old value), and `set -e` treats this as a fatal error
- Fixed all standalone `((var++))` expressions across `project-install.sh`, `common-functions.sh`, and `sync-to-profile.sh` by appending `|| true`

## Steps to reproduce

```bash
cd /path/to/any/project
/path/to/agent-os/scripts/project-install.sh
```

Output stops at "Configuration:" and no files are installed.

## Test plan

- [x] Verified `project-install.sh` now completes successfully and installs all 5 commands
- [ ] Verify `sync-to-profile.sh` works with the same fix pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)