### PR TITLE
Fix silent script failures from ((var++)) with set -e

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -219,7 +219,7 @@ copy_standards() {
 
         ensure_dir "$(dirname "$dest_file")"
         cp "$file" "$dest_file"
-        ((count++))
+        count=$((count+1))
     done < <(find "$source_dir" -name "*.md" -type f ! -path "*/.backups/*" -print0 2>/dev/null)
 
     echo "$count"

--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -241,11 +241,11 @@ install_standards() {
             grep -v "^${relative_path}|" "$sources_file" > "${sources_file}.tmp" 2>/dev/null || true
             mv "${sources_file}.tmp" "$sources_file"
             echo "${relative_path}|${profile_name}" >> "$sources_file"
-            ((profile_file_count++))
+            profile_file_count=$((profile_file_count + 1))
         done < <(find "$profile_standards" -name "*.md" -type f ! -path "*/.backups/*" -print0 2>/dev/null)
 
         if [[ "$profile_file_count" -gt 0 ]]; then
-            ((profiles_used++))
+            profiles_used=$((profiles_used + 1))
         fi
     done <<< "$INHERITANCE_CHAIN"
 
@@ -335,11 +335,11 @@ create_index() {
             local desc=$(get_existing_description "root" "$filename")
             if [[ -z "$desc" ]]; then
                 desc="Needs description - run /index-standards"
-                ((new_count++))
+                new_count=$((new_count + 1))
             fi
             echo "  $filename:" >> "$temp_file"
             echo "    description: $desc" >> "$temp_file"
-            ((entry_count++))
+            entry_count=$((entry_count + 1))
         done <<< "$root_files"
         echo "" >> "$temp_file"
     fi
@@ -357,11 +357,11 @@ create_index() {
                 local desc=$(get_existing_description "$folder_name" "$filename")
                 if [[ -z "$desc" ]]; then
                     desc="Needs description - run /index-standards"
-                    ((new_count++))
+                    new_count=$((new_count + 1))
                 fi
                 echo "  $filename:" >> "$temp_file"
                 echo "    description: $desc" >> "$temp_file"
-                ((entry_count++))
+                entry_count=$((entry_count + 1))
             done <<< "$md_files"
             echo "" >> "$temp_file"
         fi
@@ -399,7 +399,7 @@ install_commands() {
     for file in "$commands_source"/*.md; do
         if [[ -f "$file" ]]; then
             cp "$file" "$commands_dest/"
-            ((count++))
+            count=$((count + 1))
         fi
     done
 
@@ -447,7 +447,7 @@ main() {
             done
             chain_display="$chain_display"$'\n'"$indent  ↳ inherits from: $profile_name"
         fi
-        ((chain_depth++))
+        chain_depth=$((chain_depth + 1))
     done <<< "$reversed_chain"
     echo "$chain_display"
 

--- a/scripts/sync-to-profile.sh
+++ b/scripts/sync-to-profile.sh
@@ -194,7 +194,7 @@ select_profile() {
 
     for profile in "${profiles[@]}"; do
         echo "  $i) $profile"
-        ((i++))
+        i=$((i + 1))
     done
     echo "  $i) [Create new profile]"
     echo ""
@@ -273,7 +273,7 @@ select_files() {
             else
                 echo "  $i) [ ] $file"
             fi
-            ((i++))
+            i=$((i + 1))
         done
         echo ""
         echo ""
@@ -449,7 +449,7 @@ backup_files() {
         if [[ -f "$source_file" ]]; then
             mkdir -p "$(dirname "$backup_file")"
             cp "$source_file" "$backup_file"
-            ((backup_count++))
+            backup_count=$((backup_count + 1))
             print_verbose "Backed up: $file"
         fi
     done
@@ -477,7 +477,7 @@ execute_sync() {
 
         # Copy the file
         cp "$source_file" "$dest_file"
-        ((sync_count++))
+        sync_count=$((sync_count + 1))
         print_verbose "Synced: $file"
     done
 


### PR DESCRIPTION
Bug #1: Silent Script Failure from ((var++)) with set -e
Severity: High — scripts silently exit with no error message
Problem
Multiple scripts use the pattern ((count++)) to increment counters. When the variable is 0, the expression ((0++)) evaluates to 0, which bash treats as exit status 1 (falsy). Combined with set -e (which all three scripts use), this silently kills the script.
Affected Files and Lines
scripts/project-install.sh:

Line 244: ((profile_file_count++)) — standards installation counter
Line 248: ((profiles_used++)) — profiles used counter
Line 401: ((count++)) — commands installation counter
Line 448: ((chain_depth++)) — inheritance chain display counter

scripts/common-functions.sh:

Line 222: ((count++)) — file copy counter

scripts/sync-to-profile.sh:

Line 197: ((i++)) — profile listing counter
Line 276: ((i++)) — file display counter
Line 452: ((backup_count++)) — backup counter
Line 480: ((sync_count++)) — sync counter

Reproduction
bash# This demonstrates the issue:
bash -c 'set -e; count=0; ((count++)); echo "This never prints"'

# Compare with a non-zero start value (works fine):
bash -c 'set -e; count=1; ((count++)); echo "This prints"'
Observed Behavior
Running project-install.sh on a fresh v3 install:

Script prints "Configuration:" and then silently exits
No error message displayed
Exit happens at the inheritance chain display loop (line 448)
If that line is fixed, the script proceeds but installs only 1 of 5 commands before silently exiting at line 401

Fix
Replace all ((var++)) patterns with the POSIX-safe form:
bash# Before (fails when var is 0 with set -e)
((count++))

# After (always safe)
count=$((count + 1))
Note: for ((i=0; i<n; i++)) loop constructs are NOT affected — only standalone ((var++)) statements.
References
This is a well-documented bash behavior:

https://www.gnu.org/software/bash/manual/html_node/Shell-Arithmetic.html
The (( )) compound command returns exit status 1 when the expression evaluates to 0